### PR TITLE
Exclude .DS_Store generated by Mac OSX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,6 @@ ENV/
 
 # JetBrains
 .idea/
+
+# Mac stuff
+.DS_Store


### PR DESCRIPTION
Exclude from Git the .DS_Store directory, generated by Mac OSX.
