### PR TITLE
Fix #26: use correct username and domain for dashboard users.

### DIFF
--- a/user_sync/rules.py
+++ b/user_sync/rules.py
@@ -663,7 +663,7 @@ class RuleProcessor(object):
         '''
         :type dashboard_user: dict
         '''
-        return RuleProcessor.get_user_key(None, None, dashboard_user['email'])
+        return RuleProcessor.get_user_key(dashboard_user['username'], dashboard_user['domain'], dashboard_user['email'])
     
     @staticmethod
     def get_user_key(username, domain, email):


### PR DESCRIPTION
For some reason the username and domain returned by the dashboard for a user were being ignored when constructing the `user_key`.  For federatedID users where the username is not the email, this caused the user key to differ from the one constructed for directory users.