### PR TITLE
Integrate the extension example files from v1 for use on master.

### DIFF
--- a/examples/example.extension.user-sync-config.yml
+++ b/examples/example.extension.user-sync-config.yml
@@ -1,0 +1,119 @@
+dashboard:
+  # specifies the configurations for the Adobe Enterprise Dashboards.  
+  # By default, it would look for dashboard-owning-config.yml and
+  # dashboard-accessor-*-config.yml in the configuration path,
+  # with the yml's identifying the owning organization and accessor organizations
+  # respectively.
+  #  
+  # You can also specify the configurations under this section too,
+  # with keys owning and accessors.
+  #
+  # Examples:
+  # owning: example.dashboard-config.yml
+  # accessors:
+  #   org1: example.dashboard-config.yml    
+
+  # specifies the filename format for the accessor org configurations.
+  # a filename that matches the format will have the organization name extracted
+  # from the filename. Default is:
+  # accessor_config_filename_format: "dashboard-accessor-{organization_name}-config.yml"
+
+directory:
+  # (optional) Default country code to use if directory doesn't provide one for a user [Must be two-letter ISO-3166 code - see https://en.wikipedia.org/wiki/ISO_3166-1]
+  #
+  # example:
+  # default_country_code: US
+
+  connectors:
+    # specifies the configurations for the difference directory connectors
+    # The format is name : value, where value can be:
+    # a dictionary for the actual configuration, or
+    # a string for the file containing the configuration, or
+    # a list containing a mixture of dictionaries and strings
+    #
+    # examples:
+    # ldap: example.connector-ldap.yml
+    # ldap:
+    #   - host: LDAP_host_URL_goes_here
+    #     base_dn: base_DN_goes_here
+    #   - connector-ldap-credentials.yml
+
+  groups:
+    # specifies the list of group mappings, with each group mapping consisting
+    # of a dictionary with keys: directory_group and dashboard_groups.
+    # directory_group: string identifying the group in the directory
+    # dashboard_groups: a list of strings identifying the dashboard groups.
+    #
+    # a group in dashboard_groups can be qualified with, the first part being
+    # the accessor organization name.
+    # e.g. org1::Default Acrobat Pro DC configuration
+    #
+    # examples:
+    # - directory_group: AdobeCC-All #Group CN
+    #   dashboard_groups:
+    #     - All Apps
+    # - directory_group: AdobeCC-Photoshop
+    #   dashboard_groups:
+    #     - Photoshop Users
+    # - directory_group: acrobat
+    #   dashboard_groups:
+    #     - org1::Default Acrobat Pro DC configuration
+
+  # specifies the default identity type of the dashboard user to create,
+  # when the identity type of a user is missing.
+  # valid values are: enterpriseID, federatedID
+  #
+  # Default is:
+  # user_identity_type: enterpriseID
+
+
+extensions:
+  # specifies custom Python code to be executed for each user after mappings are computed, but before actions are generated.
+  # 'context' must be present and (currently) must have the value 'per-user'.
+  #
+  # hook code executes in a scope containing the following global variables:
+  #
+  #     source_attributes   # in: attributes retrieved from customer directory system (eg 'c', 'givenName')
+  #                         # out: N/A
+  #     source_groups       # in: customer-side directory groups found for user
+  #                         # out: N/A
+  #     target_attributes   # in: user's attributes for UMAPI calls as defined by usual rules (eg 'country', 'firstname')
+  #                         # out: user's attributes for UMAPI calls as potentially changed by hook code
+  #     target_groups       # in: Adobe-side dashboard groups mapped for user by usual rules
+  #                         # out: Adobe-side dashboard groups as potentially changed by hook code
+  #     hook_storage        # for exclusive use by hook code: initialized to None; persists across per-user calls
+  #     logger              # an object of type logging.logger which outputs to the console and/or file log
+  #
+  - context: per-user
+    extended_attributes:
+      - bc
+      - subco
+    extended_dashboard_groups:
+      - Company 1 Users
+      - Company 2 Users
+    after_mapping_hook: |
+      bc = source_attributes.get('bc')
+      subco = source_attributes.get('subco')
+      if bc is not None:
+        target_attributes['country'] = bc[0:2]
+      if subco == 'Company 1':
+        target_groups.add('Company 1 Users')
+      elif subco == 'Company 2':
+        target_groups.add('Company 2 Users')
+
+limits:
+    max_deletions_per_run: 10    # if --remove-nonexistent-users is specified, this is the most users that will be removed.  Others will be left for a later run.  A critical message will be logged.
+    max_missing_users: 200       # if more than this number of user accounts are not found in the directory, user sync will abort with an error and a critical message will be logged.
+
+logging:
+  # specifies whether you wish to generate a log file
+  # 'True' or 'False'
+  log_to_file: True
+  # output path for logs
+  file_log_directory: logs
+  # File Logging Level: Can be "debug", "info", "warning", "error", or "critical".  
+  # This is in ascending order, meaning "debug" < "critical".
+  file_log_level: debug
+  # Console Logging Level: Can be "debug", "info", "warning", "error", or "critical".  
+  # This is in ascending order, meaning "debug" < "critical".  Default is:
+  # console_log_level: debug

--- a/examples/example.extension.users-file.csv
+++ b/examples/example.extension.users-file.csv
@@ -1,0 +1,4 @@
+firstname,lastname,email,country,groups,bc,subco,type,user,domain
+Hook1,User,hook1@example.net,US,,JP1234567,"Company 1",federatedID
+Hook2,User,hook2@example.net,US,,GB0070008,"Company 2",federatedID
+Hook3,User,hook3@example.net,US,,FR4444444,"Company 3",federatedID


### PR DESCRIPTION
Remove references to Adobe ID as an default new user type.

This is meant to be part of the doc of v1.1, the existing release sitting on master.