### PR TITLE
updated documentation to include instructions for "--users mapped" parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ It takes a list of enterprise directory users,
 either from an LDAP connection or from a tab-separated file, 
 and creates, updates, or removes user accounts in the
 Admin Console.
-
+/Users/imak/github-adobe/user-sync.py/docs/success-guide/index.md
 # Requirements
 
 * Python 2.7+
@@ -77,7 +77,7 @@ optional arguments:
   --users all|file|mapped|group [arg1 ...]
                         specify the users to be considered for sync. Legal
                         values are 'all' (the default), 'group name or names'
-                        (one or more specified AD groups), 'mapped' (all groups
+                        (one or more specified groups), 'mapped' (all groups
                         listed in configuration file), 'file f' (a specified
                         input file).
   --user-filter pattern

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ It takes a list of enterprise directory users,
 either from an LDAP connection or from a tab-separated file, 
 and creates, updates, or removes user accounts in the
 Admin Console.
-/Users/imak/github-adobe/user-sync.py/docs/success-guide/index.md
+
 # Requirements
 
 * Python 2.7+

--- a/README.md
+++ b/README.md
@@ -74,11 +74,12 @@ optional arguments:
   --config-filename filename
                         main config filename. (default: "user-sync-
                         config.yml")
-  --users all|file|group [arg1 ...]
+  --users all|file|mapped|group [arg1 ...]
                         specify the users to be considered for sync. Legal
                         values are 'all' (the default), 'group name or names'
-                        (one or more specified AD groups), 'file f' (a
-                        specified input file).
+                        (one or more specified AD groups), 'mapped' (all groups
+                        listed in configuration file), 'file f' (a specified
+                        input file).
   --user-filter pattern
                         limit the selected set of users that may be examined
                         for syncing, with the pattern being a regular

--- a/docs/success-guide/command_line_options.md
+++ b/docs/success-guide/command_line_options.md
@@ -15,7 +15,7 @@ The command line for user sync selects the set of users to be processed, specifi
 | ------------- |:-------------| 
 |   `--users all` |    All users listed in the directory are included.  |
 |   `--users group "g1,g2,g3"`  |    The named directory groups are used to form the user selection. <br>Users that are members of any of the groups are included.  |
-|   `--users mapped`  |    The same as --users group [...], but includes all directory groups defined in the configuration file. |
+|   `--users mapped`  |    The same as `--users group g1,g2,g3,...`, where `g1,g2,g3,...` are all the directory groups specified in the configuration file group mapping.|
 |   `--users file f`  |    The file f is read to form the selected set of users.  The LDAP directory is not used in this case. |
 |   `--user-filter pattern`    |  Can be combined with the above options to further filter and reduce the user selection. <br>`pattern` is a string in Python regular expression format.  <br>The user name must match the pattern in order to be included.  <br>Writing patterns can be somewhat of an art.  See examples below or refer to the Python documentation [here](https://docs.python.org/2/library/re.html). |
 

--- a/docs/success-guide/command_line_options.md
+++ b/docs/success-guide/command_line_options.md
@@ -15,6 +15,7 @@ The command line for user sync selects the set of users to be processed, specifi
 | ------------- |:-------------| 
 |   `--users all` |    All users listed in the directory are included.  |
 |   `--users group "g1,g2,g3"`  |    The named directory groups are used to form the user selection. <br>Users that are members of any of the groups are included.  |
+|   `--users mapped`  |    The same as --users group [...], but includes all directory groups defined in the configuration file. |
 |   `--users file f`  |    The file f is read to form the selected set of users.  The LDAP directory is not used in this case. |
 |   `--user-filter pattern`    |  Can be combined with the above options to further filter and reduce the user selection. <br>`pattern` is a string in Python regular expression format.  <br>The user name must match the pattern in order to be included.  <br>Writing patterns can be somewhat of an art.  See examples below or refer to the Python documentation [here](https://docs.python.org/2/library/re.html). |
 

--- a/docs/user-manual/index.md
+++ b/docs/user-manual/index.md
@@ -782,7 +782,7 @@ specific behavior in various situations.
 | `-v`<br />`--version` | Show program's version number and exit.  |
 | `-t`<br />`--test-mode` | Run API action calls in test mode (does not execute changes). Logs what would have been executed.  |
 | `-c` _filename_<br />`--config-filename` _filename_ | The complete path to the main configuration file, absolute or relative to the working folder. Default filename is "user-sync-config.yml" |
-| `--users` `all`<br />`--users` `file` _input_path_<br />`--users` `mapped`<br />`--users` `group` _grp1,grp2_ | Specify the users to be selected for sync. The default is `all` meaning all users found in the directory. Specifying `file` means to take input user specifications from the CSV file named by the argument. Specifying `group` interprets the argument as a comma-separated list of groups in the enterprise directory, and only users in those groups are selected. Specifying `mapped` is the same as specifying `group` with all groups listed in the group mapping in the configuration file. |
+| `--users` `all`<br />`--users` `file` _input_path_<br />`--users` `group` _grp1,grp2_<br />`--users` `mapped` | Specify the users to be selected for sync. The default is `all` meaning all users found in the directory. Specifying `file` means to take input user specifications from the CSV file named by the argument. Specifying `group` interprets the argument as a comma-separated list of groups in the enterprise directory, and only users in those groups are selected. Specifying `mapped` is the same as specifying `group` with all groups listed in the group mapping in the configuration file. |
 | `--user-filter` _regex\_pattern_ | Limit the set of users that are examined for syncing to those matching a pattern specified with a regular expression. See the [Python regular expression documentation](https://docs.python.org/2/library/re.html) for information on constructing regular expressions in Python. |
 | `--source-filter` _connector_:_file_ | Names a file containing LDAP filter settings. The filter is an LDAP query string that is passed directly to the LDAP server.  See the [sample above](#connector_ldap.yml) and others in the archive of examples. |
 | `--update-user-info` | When supplied, synchronizes user information. If the information differs between the customer side and the Adobe side, the Adobe side is updated to match. This includes the firstname and lastname fields. |
@@ -914,10 +914,10 @@ configuration or user group management.
 ./user-sync –c user-sync-config.yml --users groups "group1, group2, group3"
 ```
 
-#### Sync only users listed in the group mapping in the configuration file
+#### Sync only users in mapped groups
 
-This action is the same as specifying `--users groups "..."`, but adds all the
-groups in the group mapping in the configuration file.
+This action is the same as specifying `--users groups "..."`, where `...` is all
+the groups in the group mapping in the configuration file.
 
 ```sh
 ./user-sync –c user-sync-config.yml --users mapped

--- a/docs/user-manual/index.md
+++ b/docs/user-manual/index.md
@@ -782,7 +782,7 @@ specific behavior in various situations.
 | `-v`<br />`--version` | Show program's version number and exit.  |
 | `-t`<br />`--test-mode` | Run API action calls in test mode (does not execute changes). Logs what would have been executed.  |
 | `-c` _filename_<br />`--config-filename` _filename_ | The complete path to the main configuration file, absolute or relative to the working folder. Default filename is "user-sync-config.yml" |
-| `--users` `all`<br />`--users` `file` _input_path_<br />`--users` `group` _grp1,grp2_ | Specify the users to be selected for sync. The default is `all` meaning all users found in the directory. Specifying `file` means to take input user specifications from the CSV file named by the argument.  Specifying `group` interprets the argument as a comma-separated list of groups in the enterprise directory, and only users in those groups are selected. |
+| `--users` `all`<br />`--users` `file` _input_path_<br />`--users` `mapped`<br />`--users` `group` _grp1,grp2_ | Specify the users to be selected for sync. The default is `all` meaning all users found in the directory. Specifying `file` means to take input user specifications from the CSV file named by the argument. Specifying `mapped` is the same as specifying `group` with all groups listed in the configuration file. Specifying `group` interprets the argument as a comma-separated list of groups in the enterprise directory, and only users in those groups are selected. |
 | `--user-filter` _regex\_pattern_ | Limit the set of users that are examined for syncing to those matching a pattern specified with a regular expression. See the [Python regular expression documentation](https://docs.python.org/2/library/re.html) for information on constructing regular expressions in Python. |
 | `--source-filter` _connector_:_file_ | Names a file containing LDAP filter settings. The filter is an LDAP query string that is passed directly to the LDAP server.  See the [sample above](#connector_ldap.yml) and others in the archive of examples. |
 | `--update-user-info` | When supplied, synchronizes user information. If the information differs between the customer side and the Adobe side, the Adobe side is updated to match. This includes the firstname and lastname fields. |
@@ -912,6 +912,15 @@ configuration or user group management.
 
 ```sh
 ./user-sync –c user-sync-config.yml --users groups "group1, group2, group3"
+```
+
+#### Sync only users in given groups
+
+This action is the same as specifying --users groups "...", but adds all
+the groups in the configuration files as the specified groups.
+
+```sh
+./user-sync –c user-sync-config.yml --users mapped
 ```
 
 #### Sync only matching users

--- a/docs/user-manual/index.md
+++ b/docs/user-manual/index.md
@@ -782,7 +782,7 @@ specific behavior in various situations.
 | `-v`<br />`--version` | Show program's version number and exit.  |
 | `-t`<br />`--test-mode` | Run API action calls in test mode (does not execute changes). Logs what would have been executed.  |
 | `-c` _filename_<br />`--config-filename` _filename_ | The complete path to the main configuration file, absolute or relative to the working folder. Default filename is "user-sync-config.yml" |
-| `--users` `all`<br />`--users` `file` _input_path_<br />`--users` `mapped`<br />`--users` `group` _grp1,grp2_ | Specify the users to be selected for sync. The default is `all` meaning all users found in the directory. Specifying `file` means to take input user specifications from the CSV file named by the argument. Specifying `mapped` is the same as specifying `group` with all groups listed in the configuration file. Specifying `group` interprets the argument as a comma-separated list of groups in the enterprise directory, and only users in those groups are selected. |
+| `--users` `all`<br />`--users` `file` _input_path_<br />`--users` `mapped`<br />`--users` `group` _grp1,grp2_ | Specify the users to be selected for sync. The default is `all` meaning all users found in the directory. Specifying `file` means to take input user specifications from the CSV file named by the argument. Specifying `group` interprets the argument as a comma-separated list of groups in the enterprise directory, and only users in those groups are selected. Specifying `mapped` is the same as specifying `group` with all groups listed in the group mapping in the configuration file. |
 | `--user-filter` _regex\_pattern_ | Limit the set of users that are examined for syncing to those matching a pattern specified with a regular expression. See the [Python regular expression documentation](https://docs.python.org/2/library/re.html) for information on constructing regular expressions in Python. |
 | `--source-filter` _connector_:_file_ | Names a file containing LDAP filter settings. The filter is an LDAP query string that is passed directly to the LDAP server.  See the [sample above](#connector_ldap.yml) and others in the archive of examples. |
 | `--update-user-info` | When supplied, synchronizes user information. If the information differs between the customer side and the Adobe side, the Adobe side is updated to match. This includes the firstname and lastname fields. |
@@ -914,10 +914,10 @@ configuration or user group management.
 ./user-sync –c user-sync-config.yml --users groups "group1, group2, group3"
 ```
 
-#### Sync only users in given groups
+#### Sync only users listed in the group mapping in the configuration file
 
-This action is the same as specifying --users groups "...", but adds all
-the groups in the configuration files as the specified groups.
+This action is the same as specifying `--users groups "..."`, but adds all the
+groups in the group mapping in the configuration file.
 
 ```sh
 ./user-sync –c user-sync-config.yml --users mapped


### PR DESCRIPTION
basically updated main README, user manual, and success guide to make
it clear to the user that `--users mapped` is shorthand for including all
directory groups in the sync.