### PR TITLE
fix for unhandled exception when slight error in config file

### DIFF
--- a/user_sync/config.py
+++ b/user_sync/config.py
@@ -257,11 +257,15 @@ class ConfigLoader(object):
         try:
             with open(file_path, 'r', 1) as input_file:
                 return yaml.load(input_file)
+        except IOError as e:
+            # if a file operation error occurred while loading the
+            # configuration file, swallow up the exception and re-raise this
+            # as an configuration loader exception.
+            raise user_sync.error.AssertionException('Error reading configuration file: %s' % e)
         except yaml.error.MarkedYAMLError as e:
-            # if a parser error occured while loading the configuration file,
-            # swallow the error and re-raise it as a configuration loader
-            # exception
-            raise user_sync.error.AssertionException('Error loading configuration file: %s' % e)
+            # same as above, but indicate this problem has to do with
+            # parsing the configuration file.
+            raise user_sync.error.AssertionException('Error parsing configuration file: %s' % e)
         
     def get_file_path(self, filename):
         '''

--- a/user_sync/config.py
+++ b/user_sync/config.py
@@ -254,8 +254,14 @@ class ConfigLoader(object):
         '''
         :type file_path: str
         '''        
-        with open(file_path, 'r', 1) as input_file:
-            return yaml.load(input_file)
+        try:
+            with open(file_path, 'r', 1) as input_file:
+                return yaml.load(input_file)
+        except yaml.error.MarkedYAMLError as e:
+            # if a parser error occured while loading the configuration file,
+            # swallow the error and re-raise it as a configuration loader
+            # exception
+            raise user_sync.error.AssertionException('Error loading configuration file: %s' % e)
         
     def get_file_path(self, filename):
         '''


### PR DESCRIPTION
config parser errors now have the following form:

```log
2017-03-15 14:10:50 47278 CRITICAL main - Error loading configuration
file: while parsing a block mapping
in "user-sync-config.yml", line 1, column 1
expected <block end>, but found '<block mapping start>'
in "user-sync-config.yml", line 104, column 5
```