### PR TITLE
First work on #87.

### DIFF
--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -79,7 +79,7 @@ class ConfigLoaderTest(unittest.TestCase):
     def test_get_dict_from_sources_str_found(self, mock_isfile):
         # IOError when file is found, but not loaded by load_from_yaml
         mock_isfile.return_value = True
-        self.assertRaises(IOError, lambda: self.conf_load.get_dict_from_sources(['test'], ''))
+        self.assertRaises(AssertionException, lambda: self.conf_load.get_dict_from_sources(['test'], ''))
 
     @mock.patch('user_sync.config.ConfigLoader.get_dict_from_sources')
     def test_create_dashboard_options(self, mock_dict):
@@ -95,23 +95,29 @@ class ConfigLoaderTest(unittest.TestCase):
         mock_id_type.return_value = 'new_acc'
         mock_get_dict.return_value = tests.helper.MockGetString()
         mock_get_list.return_value = tests.helper.MockGetString()
-        self.assertEquals(self.conf_load.get_rule_options(),
-                          {'username_filter_regex': None,
-                           'update_user_info': True,
-                           'manage_groups': True,
-                           'max_deletions_per_run': 1,
-                           'max_missing_users': 1,
-                           'new_account_type': 'new_acc',
-                           'managed_identity_types': [user_sync.identity_type.ENTERPRISE_IDENTITY_TYPE,
-                                                      user_sync.identity_type.FEDERATED_IDENTITY_TYPE],
-                           'directory_group_filter': None,
-                           'default_country_code': 'test',
-                           'remove_user_key_list': None,
-                           'remove_list_output_path': None,
-                           'remove_nonexistent_users': False,
-                           'after_mapping_hook': None,
-                           'extended_attributes': None,
-                           },
+        options = self.conf_load.get_rule_options()
+        expected = {
+            'after_mapping_hook': None,
+            'default_country_code': 'test',
+            'delete_list_output_path': None,
+            'delete_nonexistent_users': False,
+            'delete_user_key_list': None,
+            'directory_group_filter': None,
+            'directory_group_mapped': False,
+            'exclude_identity_types': [],
+            'extended_attributes': None,
+            'manage_groups': True,
+            'max_deletions_per_run': 1,
+            'max_missing_users': 1,
+            'new_account_type': 'new_acc',
+            'remove_list_output_path': None,
+            'remove_nonexistent_users': False,
+            'remove_user_key_list': None,
+            'update_user_info': True,
+            'username_filter_regex': None,
+        }
+        self.assertEquals(options,
+                          expected,
                           'rule options are returned')
 
     def test_parse_string(self):

--- a/user_sync/app.py
+++ b/user_sync/app.py
@@ -201,10 +201,10 @@ def create_config_loader_options(args):
     config_options = {
         'test_mode': args.test_mode,        
         'manage_groups': args.manage_groups,
-        'update_user_info': args.update_user_info,        
+        'update_user_info': args.update_user_info,
+        'directory_group_mapped': False,
     }
 
-    config_options['directory_group_mapped'] = False
     users_args = args.users
     if (users_args != None):
         users_action = None if len(users_args) == 0 else user_sync.helper.normalize_string(users_args.pop(0))


### PR DESCRIPTION
Alters `managed_identity_types` to be `exclude_identity_types`.

This involved the following changes:
* Take out the exclude filtering on `orphan_dashboard_users`, because all of the filtering now happens in the comparison function, and it just doesn't add a user to the `orphan_user_list` if it's been excluded.
* Make sure logging isn't done of excluded users unless it would actually prevent them from being operated on.
* Remove the filtering by type that was done on creates, because creates are no longer controlled.
* Proposed to make the key go in the `dashboard` section.

There was also cleanup of a number of issues in the work on `--users mapped` and `--delete-nonexistent-users` and #49:
* Some syntax updates
* Fix the default config values to include the newly introduced values
* Fix the tests to work with the new exceptions and config values