### PR TITLE
Fix #48: Support identity type as LDAP attribute value.

### DIFF
--- a/tests/rules_test.py
+++ b/tests/rules_test.py
@@ -117,7 +117,7 @@ class RulesTest(unittest.TestCase):
                        'firstname': '!Openldap CCE',
                        'country': user_country_code,
                        'lastname': 'User1',
-                       'identitytype': identity_type,
+                       'identity_type': identity_type,
                        'email': 'cceuser1@ensemble.ca',
                        'uid': '001'}
         }

--- a/user_sync/config.py
+++ b/user_sync/config.py
@@ -336,10 +336,8 @@ class ConfigLoader(object):
             exclude_users_regexps = dashboard_config.get_list('exclude_users', True) or []
             exclude_group_names = dashboard_config.get_list('exclude_groups', True) or []
         for name in exclude_identity_type_names:
-            identity_type = user_sync.identity_type.parse_identity_type(name)
-            if not identity_type:
-                validation_message = 'Illegal value for %s in config file: %s' % ('exclude_identity_types', name)
-                raise user_sync.error.AssertionException(validation_message)
+            message_format = 'Illegal value in exclude_identity_types: %s'
+            identity_type = user_sync.identity_type.parse_identity_type(name, message_format)
             exclude_identity_types.append(identity_type)
         for regexp in exclude_users_regexps:
             try:

--- a/user_sync/connector/directory_csv.py
+++ b/user_sync/connector/directory_csv.py
@@ -161,7 +161,7 @@ class CSVDirectoryConnector(object):
             identity_type = self.get_column_value(row, identity_type_column_name)
             if identity_type is not None:
                 try:
-                    user['identitytype'] = user_sync.identity_type.parse_identity_type(identity_type) 
+                    user['identity_type'] = user_sync.identity_type.parse_identity_type(identity_type)
                 except user_sync.error.AssertionException as e:
                     logger.error('%s for user: %s', e.message, username)
                     e.set_reported()

--- a/user_sync/connector/helper.py
+++ b/user_sync/connector/helper.py
@@ -34,7 +34,7 @@ def create_blank_user():
     :rtype dict
     '''
     user = {
-        "identitytype": None,
+        "identity_type": None,
         "username": None,
         "domain": None,
         "firstname": None,

--- a/user_sync/rules.py
+++ b/user_sync/rules.py
@@ -421,7 +421,7 @@ class RuleProcessor(object):
         return attributes
     
     def get_identity_type_from_directory_user(self, directory_user):
-        identity_type = directory_user.get('identitytype')
+        identity_type = directory_user.get('identity_type')
         if (identity_type == None):
             identity_type = self.options['new_account_type']
             self.logger.warning('Found user with no identity type, using %s: %s', identity_type, directory_user)


### PR DESCRIPTION
* Add support for an identity_type (customizable) attribute definition a la email and others.
* Regularize spelling to 'identity_type' everywhere in directory/CSV user dictionaries.