### PR TITLE
Issue 30/file paths in config files should be interpreted relative to the file in which they appear 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,7 @@ optional arguments:
   -v, --version         show program's version number and exit
   -t, --test-mode       run API action calls in test mode (does not execute
                         changes). Logs what would have been executed.
-  -c path, --config-path path
-                        specify path to config files. (default: "")
-  --config-filename filename
+  -c, --config-filename filename
                         main config filename. (default: "user-sync-
                         config.yml")
   --users all|file|mapped|group [arg1 ...]

--- a/tests/rules_test.py
+++ b/tests/rules_test.py
@@ -117,7 +117,7 @@ class RulesTest(unittest.TestCase):
                        'firstname': '!Openldap CCE',
                        'country': user_country_code,
                        'lastname': 'User1',
-                       'identitytype': identity_type,
+                       'identity_type': identity_type,
                        'email': 'cceuser1@ensemble.ca',
                        'uid': '001'}
         }

--- a/user_sync/app.py
+++ b/user_sync/app.py
@@ -45,10 +45,7 @@ def process_args():
     parser.add_argument('-t', '--test-mode',
                         help='run API action calls in test mode (does not execute changes). Logs what would have been executed.',
                         action='store_true', dest='test_mode')
-    parser.add_argument('-c', '--config-path',
-                        help='specify path to config files. (default: "%(default)s")',
-                        default=config.DEFAULT_CONFIG_DIRECTORY, metavar='path', dest='config_path')
-    parser.add_argument('--config-filename',
+    parser.add_argument('-c', '--config-filename',
                         help='main config filename. (default: "%(default)s")',
                         default=config.DEFAULT_MAIN_CONFIG_FILENAME, metavar='filename', dest='config_filename')
     parser.add_argument('--users', 
@@ -126,7 +123,7 @@ def init_log(logging_config):
         if (file_log_level == None):
             file_log_level = logging.INFO
             unknown_file_log_level = True
-        file_log_directory = options['file_log_directory']
+        file_log_directory = user_sync.config.ConfigFileLoader.get_relative_filename(options['file_log_directory'])
         if not os.path.exists(file_log_directory):
             os.makedirs(file_log_directory)
         
@@ -191,7 +188,6 @@ def begin_work(config_loader):
     
 def create_config_loader(args):
     config_bootstrap_options = {
-        'config_directory': args.config_path,
         'main_config_filename': args.config_filename,
     }
     config_loader = user_sync.config.ConfigLoader(config_bootstrap_options)

--- a/user_sync/config.py
+++ b/user_sync/config.py
@@ -30,7 +30,6 @@ import user_sync.error
 import user_sync.identity_type
 import user_sync.rules
 
-DEFAULT_CONFIG_DIRECTORY = ''
 DEFAULT_MAIN_CONFIG_FILENAME = 'user-sync-config.yml'
 DEFAULT_DASHBOARD_OWNING_CONFIG_FILENAME = 'dashboard-owning-config.yml'
 DEFAULT_DASHBOARD_ACCESSOR_CONFIG_FILENAME_FORMAT = 'dashboard-accessor-{organization_name}-config.yml'
@@ -42,7 +41,6 @@ class ConfigLoader(object):
         '''        
         self.options = options = {
             # these are in alphabetical order!  Always add new ones that way!
-            'config_directory': DEFAULT_CONFIG_DIRECTORY,
             'delete_list_output_path': None,
             'delete_nonexistent_users': False,
             'delete_user_key_list': None,
@@ -63,17 +61,16 @@ class ConfigLoader(object):
         options.update(caller_options)     
 
         main_config_filename = options.get('main_config_filename')
-        self.main_config_path = main_config_path = self.get_file_path(main_config_filename)
+        ConfigFileLoader.load(main_config_filename)
         
-        if (not os.path.isfile(main_config_path)):
-            raise user_sync.error.AssertionException('Config file does not exist: %s' % (main_config_path))  
+        if (not os.path.isfile(main_config_filename)):
+            raise user_sync.error.AssertionException('Config file does not exist: %s' % (main_config_filename))  
         
         self.directory_source_filters_accessed = set()        
         
         self.logger = logger = logging.getLogger('config')
-        logger.info("Using main config file: %s", main_config_path)                
-        config_content = self.load_from_yaml(self.main_config_path)         
-        self.main_config = DictConfig("<%s>" % main_config_filename, config_content)
+        logger.info("Using main config file: %s", main_config_filename)                
+        self.main_config = DictConfig("<%s>" % main_config_filename, ConfigFileLoader.content)
         
     def set_options(self, caller_options):          
         '''
@@ -111,7 +108,7 @@ class ConfigLoader(object):
             
         accessor_config_file_paths = {}
         accessor_config_filename_wildcard = accessor_config_filename_format.format(**{'organization_name': '*'})
-        for file_path in glob.glob1(self.options.get('config_directory'), accessor_config_filename_wildcard):
+        for file_path in glob.glob1(ConfigFileLoader.dirpath, accessor_config_filename_wildcard):
             parse_result = self.parse_string(accessor_config_filename_format, file_path)
             organization_name = parse_result.get('organization_name')
             if (organization_name != None):
@@ -129,7 +126,7 @@ class ConfigLoader(object):
             accessor_config = None
             if (accessors_config != None): 
                 accessor_config = accessors_config.get_list(organization_name, True) 
-            accessor_config_sources = self.as_list(accessor_config)
+            accessor_config_sources = ConfigFileLoader.get_relative_filenames(self.as_list(accessor_config))
             accessor_config_file_path = accessor_config_file_paths.get(organization_name, None)
             if (accessor_config_file_path != None):
                 accessor_config_sources.append(accessor_config_file_path)
@@ -233,7 +230,7 @@ class ConfigLoader(object):
             if (isinstance(source, types.StringTypes)):
                 absolute_path = self.get_absolute_file_path(source)
                 if (os.path.isfile(absolute_path)):
-                    config = self.load_from_yaml(absolute_path)
+                    config = ConfigFileLoader.load_from_yaml(absolute_path)
                     options.append(config)
                 else:
                     raise user_sync.error.AssertionException('Cannot find file: %s for: %s' % (absolute_path, owner))
@@ -274,7 +271,7 @@ class ConfigLoader(object):
         :type filename: str
         :rtype str
         '''        
-        directory = self.options.get('config_directory')
+        directory = ConfigFileLoader.dirpath
         path = os.path.join(directory, filename)
         return path
 
@@ -637,6 +634,66 @@ class DictConfig(ObjectConfig):
         if (len(unused_keys) > 0):
             messages.append("Found unused keys: %s in: %s" % (unused_keys, self.get_full_scope()))
         return messages
+    
+class ConfigFileLoader(object):
+    @staticmethod
+    def load(filename):
+        '''
+        loads a configuration from a yaml file, and retains the directory
+        context
+        :type filename: str
+        :type content: dict
+        '''
+        ConfigFileLoader.filename = filename
+        ConfigFileLoader.dirpath = os.path.dirname(filename)
+        ConfigFileLoader.content = ConfigFileLoader.load_from_yaml(filename)
+        
+    @staticmethod
+    def get_relative_filename(filename):
+        '''
+        returns a filename relative to this configuration's directory context
+        :type filename: str
+        :rtype str
+        '''
+        if not os.path.isabs(filename):
+            if ConfigFileLoader.dirpath:
+                filename = ConfigFileLoader.dirpath + '/' + filename
+            
+        return filename
+
+    @staticmethod
+    def get_relative_filenames(filenames):
+        '''
+        returns a list of filenames relative to this configuration's directory
+        context
+        :type filenames: list(str)
+        :rtype list(str)
+        '''
+        new_filenames = []
+        for filename in filenames:
+            new_filenames.append(ConfigFileLoader.get_relative_filename(filename))
+            
+        return new_filenames
+    
+    @staticmethod
+    def load_from_yaml(filename):
+        '''
+        loads a yaml file and returns it as a dict.
+        :type filename: str
+        '''        
+        try:
+            with open(filename, 'r', 1) as input_file:
+                return yaml.load(input_file)
+        except IOError as e:
+            # if a file operation error occurred while loading the
+            # configuration file, swallow up the exception and re-raise this
+            # as an configuration loader exception.
+            raise user_sync.error.AssertionException('Error reading configuration file: %s' % e)
+        except yaml.error.MarkedYAMLError as e:
+            # same as above, but indicate this problem has to do with
+            # parsing the configuration file.
+            raise user_sync.error.AssertionException('Error parsing configuration file: %s' % e)
+    
     
 class OptionsBuilder(object):
     def __init__(self, default_config):

--- a/user_sync/config.py
+++ b/user_sync/config.py
@@ -333,10 +333,8 @@ class ConfigLoader(object):
             exclude_users_regexps = dashboard_config.get_list('exclude_users', True) or []
             exclude_group_names = dashboard_config.get_list('exclude_groups', True) or []
         for name in exclude_identity_type_names:
-            identity_type = user_sync.identity_type.parse_identity_type(name)
-            if not identity_type:
-                validation_message = 'Illegal value for %s in config file: %s' % ('exclude_identity_types', name)
-                raise user_sync.error.AssertionException(validation_message)
+            message_format = 'Illegal value in exclude_identity_types: %s'
+            identity_type = user_sync.identity_type.parse_identity_type(name, message_format)
             exclude_identity_types.append(identity_type)
         for regexp in exclude_users_regexps:
             try:

--- a/user_sync/config.py
+++ b/user_sync/config.py
@@ -126,7 +126,7 @@ class ConfigLoader(object):
             accessor_config = None
             if (accessors_config != None): 
                 accessor_config = accessors_config.get_list(organization_name, True) 
-            accessor_config_sources = ConfigFileLoader.get_relative_filenames(self.as_list(accessor_config))
+            accessor_config_sources = self.as_list(accessor_config)
             accessor_config_file_path = accessor_config_file_paths.get(organization_name, None)
             if (accessor_config_file_path != None):
                 accessor_config_sources.append(accessor_config_file_path)
@@ -246,26 +246,8 @@ class ConfigLoader(object):
         make sure the path is relative from the config path.
         :type value: str
         '''        
-        path = value if os.path.isabs(value) else self.get_file_path(value)
-        return path
+        return ConfigFileLoader.get_relative_filename(value)
     
-    def load_from_yaml(self, file_path):
-        '''
-        :type file_path: str
-        '''        
-        try:
-            with open(file_path, 'r', 1) as input_file:
-                return yaml.load(input_file)
-        except IOError as e:
-            # if a file operation error occurred while loading the
-            # configuration file, swallow up the exception and re-raise this
-            # as an configuration loader exception.
-            raise user_sync.error.AssertionException('Error reading configuration file: %s' % e)
-        except yaml.error.MarkedYAMLError as e:
-            # same as above, but indicate this problem has to do with
-            # parsing the configuration file.
-            raise user_sync.error.AssertionException('Error parsing configuration file: %s' % e)
-        
     def get_file_path(self, filename):
         '''
         :type filename: str

--- a/user_sync/connector/dashboard.py
+++ b/user_sync/connector/dashboard.py
@@ -73,7 +73,7 @@ class DashboardConnector(object):
         ims_host = server_options['ims_host']
         self.org_id = org_id = enterprise_options['org_id']
         api_key = enterprise_options['api_key']
-        private_key_file_path = enterprise_options['priv_key_path']
+        private_key_file_path = user_sync.config.ConfigFileLoader.get_relative_filename(enterprise_options['priv_key_path'])
         um_endpoint = "https://" + server_options['host'] + server_options['endpoint']    
         
         logger.info('Creating connection for org id: "%s" using private key file: "%s"', org_id, private_key_file_path)

--- a/user_sync/connector/directory_csv.py
+++ b/user_sync/connector/directory_csv.py
@@ -161,7 +161,7 @@ class CSVDirectoryConnector(object):
             identity_type = self.get_column_value(row, identity_type_column_name)
             if identity_type is not None:
                 try:
-                    user['identitytype'] = user_sync.identity_type.parse_identity_type(identity_type) 
+                    user['identity_type'] = user_sync.identity_type.parse_identity_type(identity_type)
                 except user_sync.error.AssertionException as e:
                     logger.error('%s for user: %s', e.message, username)
                     e.set_reported()

--- a/user_sync/connector/helper.py
+++ b/user_sync/connector/helper.py
@@ -34,7 +34,7 @@ def create_blank_user():
     :rtype dict
     '''
     user = {
-        "identitytype": None,
+        "identity_type": None,
         "username": None,
         "domain": None,
         "firstname": None,

--- a/user_sync/rules.py
+++ b/user_sync/rules.py
@@ -421,7 +421,7 @@ class RuleProcessor(object):
         return attributes
     
     def get_identity_type_from_directory_user(self, directory_user):
-        identity_type = directory_user.get('identitytype')
+        identity_type = directory_user.get('identity_type')
         if (identity_type == None):
             identity_type = self.options['new_account_type']
             self.logger.warning('Found user with no identity type, using %s: %s', identity_type, directory_user)


### PR DESCRIPTION
* Add support for an identity_type (customizable) attribute definition a la email and others.
* Regularize spelling to 'identity_type' everywhere in directory/CSV user dictionaries.