### PR TITLE
fix #134: --adobe-only-user-action exclude doesn't work.

### DIFF
--- a/user_sync/app.py
+++ b/user_sync/app.py
@@ -206,11 +206,29 @@ def create_config_loader(args):
 
 
 def create_config_loader_options(args):
+    '''
+    This is where all the command-line arguments get set as options in the main config
+    so that it appears as if they were loaded as part of the main configuration file.
+    If you add an option that is supposed to be set from the command line here, you
+    had better make sure you add it to the ones read in get_rule_options.
+    :param args: the command-line args as parsed
+    :return: the configured options for the config loader.
+    '''
     config_options = {
-        'test_mode': args.test_mode,
-        'manage_groups': args.manage_groups,
-        'update_user_info': args.update_user_info,
+        'delete_strays': False,
+        'directory_connector_module_name': None,
+        'directory_connector_overridden_options': None,
+        'directory_group_filter': None,
         'directory_group_mapped': False,
+        'disentitle_strays': False,
+        'exclude_strays': False,
+        'manage_groups': args.manage_groups,
+        'remove_strays': False,
+        'stray_list_input_path': None,
+        'stray_list_output_path': None,
+        'test_mode': args.test_mode,
+        'update_user_info': args.update_user_info,
+        'username_filter_regex': None,
     }
 
     # --users

--- a/user_sync/config.py
+++ b/user_sync/config.py
@@ -335,6 +335,7 @@ class ConfigLoader(object):
             'disentitle_strays': options['disentitle_strays'],
             'exclude_groups': exclude_groups,
             'exclude_identity_types': exclude_identity_types,
+            'exclude_strays': options['exclude_strays'],
             'exclude_users': exclude_users,
             'extended_attributes': extended_attributes,
             'manage_groups': options['manage_groups'],

--- a/user_sync/rules.py
+++ b/user_sync/rules.py
@@ -100,11 +100,11 @@ class RuleProcessor(object):
         self.stray_list_output_path = options['stray_list_output_path']
         
         # determine whether we need to process strays at all
-        self.need_to_process_strays = not options['exclude_strays'] and (options['manage_groups'] or
-                                                                         options['stray_list_output_path'] or
-                                                                         options['disentitle_strays'] or
-                                                                         options['remove_strays'] or
-                                                                         options['delete_strays'])
+        self.will_process_strays = (not options['exclude_strays']) and (options['manage_groups'] or
+                                                                        options['stray_list_output_path'] or
+                                                                        options['disentitle_strays'] or
+                                                                        options['remove_strays'] or
+                                                                        options['delete_strays'])
 
         # in/out variables for per-user after-mapping-hook code
         self.after_mapping_hook_scope = {
@@ -151,7 +151,7 @@ class RuleProcessor(object):
         umapi_stats.log_start(logger)
         if should_sync_umapi_users:
             self.process_umapi_users(umapi_connectors)
-        if self.need_to_process_strays:
+        if self.will_process_strays:
             self.process_strays(umapi_connectors)
         umapi_connectors.execute_actions()
         umapi_stats.log_end(logger)
@@ -195,7 +195,7 @@ class RuleProcessor(object):
             ['adobe_users_created', 'Number of new Adobe users added'],
             ['adobe_users_updated', 'Number of existing Adobe users updated'],
         ]
-        if self.need_to_process_strays:
+        if self.will_process_strays:
             if self.options['delete_strays']:
                 action = 'deleted'
             elif self.options['remove_strays']:
@@ -679,7 +679,7 @@ class RuleProcessor(object):
         options = self.options
         update_user_info = options['update_user_info']
         manage_groups = self.will_manage_groups()
-        will_process_strays = self.need_to_process_strays
+        will_process_strays = self.will_process_strays
 
         # prepare the strays map if we are going to be processing them
         if will_process_strays:
@@ -689,8 +689,8 @@ class RuleProcessor(object):
         in_primary_org = umapi_info.get_name() == PRIMARY_UMAPI_NAME
 
         # we only log certain users if they are relevant to our processing.
-        log_excluded_users = update_user_info or manage_groups or will_process_strays
-        log_stray_users = manage_groups or will_process_strays
+        log_excluded_users = update_user_info or manage_groups
+        log_stray_users = will_process_strays
         log_matching_users = update_user_info or manage_groups
 
 


### PR DESCRIPTION
The problem was that the argument value was being set in the
config_loader, but get_rule_options was not picking it up and
passing it to the rules module.