### PR TITLE
Correct 2nd link to new Adobe I/O Authn doc

### DIFF
--- a/docs/success-guide/setup_adobeio.md
+++ b/docs/success-guide/setup_adobeio.md
@@ -18,9 +18,9 @@ Setup steps are documented.  For complete information about the integration setu
 - Once setup, the Adobe.io console displays all needed values.  You’ll copy these into the user sync configuration file.
 - You'll also need to add the private key file to the User Sync configuration.
 
-&#9744; Obtain or create a digital signing certificate.  See [instructions for certificate creation](https://www.adobe.io/apis/cloudplatform/usermanagement/docs/setup/createcert.html).
+&#9744; Obtain or create a digital signing certificate.  See [instructions for certificate creation](https://www.adobe.io/apis/cloudplatform/console/authentication/createcert.html).
 
-&#9744; Setup an adobe.io integration for each organization you need to access (usually only one).  See Step 2 and 3 on this [page](https://www.adobe.io/apis/cloudplatform/console/authentication/createcert.html)
+&#9744; Setup an adobe.io integration for each organization you need to access (usually only one).  See Step 2 and 3 on this [page](https://www.adobe.io/apis/cloudplatform/console/authentication/gettingstarted.html)
 
 &#9744; Note the configuration parameters for your integration (redacted example shown below).  They will be used in a later step.
 


### PR DESCRIPTION
Turns out there were two link. Both should be correct now.