### PR TITLE
Fixed --adobe-only-user-action remove-adobe-groups error

### DIFF
--- a/user_sync/connector/umapi.py
+++ b/user_sync/connector/umapi.py
@@ -170,7 +170,7 @@ class Commands(object):
             self.do_list.append(('add_to_groups', params))
 
     def remove_all_groups(self):
-        self.do_list.append(('remove_from_groups', 'all'))
+        self.do_list.append(('remove_from_groups', {'all_groups': True}))
 
     def remove_groups(self, groups_to_remove):
         '''


### PR DESCRIPTION
fixed #202

by changing 'all' to {'all_groups': True}
this resolved the issue. 

Tested with stage environment and it removed user group/plc from stray accounts.
