### PR TITLE
updated makefile to wheel packages only in 64 bit windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
+USE_WHEEL := no
 RM := rm -rf
-MKDIR := mkdir
-python_ldap_requirements := misc/build/python-ldap-requirements.txt
 
 ifeq ($(OS),Windows_NT)
 	output_file_extension = .pex
@@ -8,13 +7,10 @@ ifeq ($(OS),Windows_NT)
 ifeq ($(rm_path),None)
 	RM := rmdir /S /Q
 endif
-	mkdir_path := $(shell python -c "import distutils.spawn; print(distutils.spawn.find_executable('mkdir'))")
-ifeq ($(mkdir_path),None)
-	MKDIR := md
-endif
 	python_arch := $(shell python -c "import platform; print platform.architecture()[0]")
 ifeq ($(python_arch),64bit)
 	python_ldap_requirements := misc/build/Win64/python-ldap-requirements.txt
+	USE_WHEEL := yes
 endif
 endif
 
@@ -24,15 +20,21 @@ output_filename = user-sync
 pex:
 	pip install --upgrade pip
 	pip install pex requests wheel
-	pip wheel -w wheelhouse -r $(python_ldap_requirements)
-	-$(MKDIR) wheelhouse
 	-$(RM) $(output_dir)
+ifeq ($(USE_WHEEL),yes)
+	pip wheel -w wheelhouse -r $(python_ldap_requirements)
 	pex \
 		-v -o $(output_dir)/$(output_filename)$(output_file_extension) -m user_sync.app \
 		-f wheelhouse \
 		--disable-cache \
 		--not-zip-safe .
 	-$(RM) wheelhouse
+else
+	pex \
+		-v -o $(output_dir)/$(output_filename)$(output_file_extension) -m user_sync.app \
+		--disable-cache \
+		--not-zip-safe .
+endif
 
 test:
 	nosetests --no-byte-compile tests


### PR DESCRIPTION
fix #211 
- make will only wheel python packages in windows 64bit platform (to archive the custom windows ldap package)
- other platforms depend entirely on pex to automatically resolve dependencies