### PR TITLE
Fix #198: secure RSA keys via passphrase in credential store

### DIFF
--- a/examples/config files - basic/2 connector-umapi.yml
+++ b/examples/config files - basic/2 connector-umapi.yml
@@ -48,7 +48,7 @@ enterprise:
   # (optional) You can store credentials in the operating system credential store
   # (Windows Credential Manager, Mac Keychain, Linux Freedesktop Secret Service
   # or KWallet - these will be built into the Linux distribution).
-  # To use this feature, uncomment the following entries and remove the 
+  # To use this feature, uncomment the following entries and remove the
   # api_key, client_secret, and priv_key_data above.
   # The actual credential values are placed in the credential store with the
   # username as the org_id value, and the key name (perhaps called internet 
@@ -56,3 +56,16 @@ enterprise:
   #secure_api_key_key: umapi_api_key
   #secure_client_secret_key: umapi_client_secret
   #secure_priv_key_data_key: umapi_private_key_data
+  # Note: the Windows credential store generally can't store data as large as a private
+  # key, so the recommended path for securing your private key on windows is given next.
+
+  # (optional): You can secure your private key data by encrypting it, as with
+  #     openssl rsa -in private.key -des3 -out private.encrypted.key
+  # which prompts for a passphrase and creates a passphrase-encrypted file in PKCS#5 format.
+  # Having done this, you can use the setting priv_key_pass to specify the passphrase needed
+  # by User Sync to decrypt the private key file (or private key data), as in:
+  #priv_key_pass: "my passphrase for my private key"
+  # For better security, you should save your passphrase into the secure credential store
+  # on your platform (username = your org ID, service/internet address = "umapi_passphrase")
+  # and then uncomment this setting:
+  #secure_priv_pass_key: umapi_private_key_passphrase

--- a/examples/config files - basic/2 connector-umapi.yml
+++ b/examples/config files - basic/2 connector-umapi.yml
@@ -60,8 +60,8 @@ enterprise:
   # key, so the recommended path for securing your private key on windows is given next.
 
   # (optional): You can secure your private key data by encrypting it, as with
-  #     openssl rsa -in private.key -des3 -out private.encrypted.key
-  # which prompts for a passphrase and creates a passphrase-encrypted file in PKCS#5 format.
+  #     openssl pkcs8 -in private.key -topk8 -v2 des3 -out private-encrypted.key
+  # which prompts for a passphrase and creates a passphrase-encrypted file in PKCS#8 format.
   # Having done this, you can use the setting priv_key_pass to specify the passphrase needed
   # by User Sync to decrypt the private key file (or private key data), as in:
   #priv_key_pass: "my passphrase for my private key"

--- a/examples/config files - basic/2 connector-umapi.yml
+++ b/examples/config files - basic/2 connector-umapi.yml
@@ -66,6 +66,6 @@ enterprise:
   # by User Sync to decrypt the private key file (or private key data), as in:
   #priv_key_pass: "my passphrase for my private key"
   # For better security, you should save your passphrase into the secure credential store
-  # on your platform (username = your org ID, service/internet address = "umapi_passphrase")
+  # on your platform (username = your org ID, service/internet address = "umapi_private_key_passphrase")
   # and then uncomment this setting:
   #secure_priv_pass_key: umapi_private_key_passphrase

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(name='user-sync',
       license='MIT',
       packages=['user_sync', 'user_sync.connector'],
       install_requires=[
-          'pycrypto',
+          'pycryptodome',
           'python-ldap==2.4.25',
           'PyYAML',
           'umapi-client>=2.5',


### PR DESCRIPTION
Since Windows doesn't support long keystore values, we can't put the RSA private keys into the keystore.  So we have added support for encryted RSA private keys (either in files or data), and we have added a credential value `priv_key_pass` (in the clear or in the secure store) which is the passphrase to decrypt the private key.

Note that encrypted RSA private keys can be in one of two formats: PKCS#5 or PKCS#8.  (See [this article](https://github.com/kjur/jsrsasign/wiki/Tutorial-for-PKCS5-and-PKCS8-PEM-private-key-formats-differences) for examples of what they look like.)  PKCS#8 keys cannot be brute-force attacked the way that PKCS#5 keys can be, so they are a lot more secure (and allow for much simpler passphrases).  Unfortunately, our version of PyCrypto doesn't support PKCS#8 private keys, and there is no released version that does (only an alpha version).  So we are transitioning to the modern, maintained BSD-licensed PyCryptoDome module which is fully API compatible with PyCrypto.