### PR TITLE
workaround for pycryptodome windows path length bug

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,6 @@ setup(name='user-sync',
       license='MIT',
       packages=['user_sync', 'user_sync.connector'],
       install_requires=[
-          'pycryptodome',
           'python-ldap==2.4.25',
           'PyYAML',
           'umapi-client>=2.5',
@@ -55,7 +54,11 @@ setup(name='user-sync',
               'dbus-python'
           ],
           ':sys_platform=="win32"':[
-              'pywin32-ctypes==0.0.1'
+              'pywin32-ctypes==0.0.1',
+              'pycryptodome==3.3.1'
+          ],
+          ':sys_platform!="win32"': [
+              'pycryptodome',
           ]
       },
       setup_requires=['nose>=1.0'],


### PR DESCRIPTION
- windows requires pycryptodome version 3.3.1
- other platforms use the latest version