### PR TITLE
Fix #182: Allow indirect membership in directory groups.

### DIFF
--- a/examples/config files - basic/3 connector-ldap.yml
+++ b/examples/config files - basic/3 connector-ldap.yml
@@ -59,14 +59,25 @@ require_tls_cert: False
 all_users_filter: "(&(objectClass=user)(objectCategory=person)(!(userAccountControl:1.2.840.113556.1.4.803:=2)))"
 
 # (optional) group_filter_format (default value given below)
-# group_filter_format specifies the format string used to construct a group query,
-# as needed by the --users groups or --users mapped command-line arguments.
+# group_filter_format specifies the format string used to get the distinguished
+# name of a group given its common name (as specified in the directory to Adobe
+# group mapping, or in the --users group "name1,name2" command-line argument).
 # {group} is replaced with the name of the group to find.  The default value here is
 # complex, because it's meant to work for both AD-style and OpenLDAP-style directories.
 # You will likely want to replace it with a simpler query customized for your directory,
 # such as this one for Active Directory: "(&(objectCategory=group)(cn={group}))"
 # or this one for OpenLDAP: "(&(|(objectClass=groupOfNames)(objectClass=posixGroup))(cn={group}))"
 group_filter_format: "(&(|(objectCategory=group)(objectClass=groupOfNames)(objectClass=posixGroup))(cn={group}))"
+
+# (optional) group_member_filter_format (default value given below)
+# group_users_filter specifies the query used to find all members of a group,
+# where the string {group_dn} is replaced with the group distinguished name.
+# The default value just finds users who are immediate members of the group,
+# not those who are "indirectly" members by virtue of membership in a group
+# that is contained in the group.  If you want indirect containment, then
+# use this value instead of the default:
+# group_member_filter_format: "(memberOf:1.2.840.113556.1.4.1941:={group_dn})"
+group_member_filter_format: "(memberOf={group_dn})"
 
 # (optional) string_encoding (default value given below)
 # string_encoding specifies the Unicode string encoding used by the directory.

--- a/tests/connector/directory_csv_test.py
+++ b/tests/connector/directory_csv_test.py
@@ -32,7 +32,7 @@ class CSVDirectoryTest(unittest.TestCase):
         }
         directory_connector.initialize(options)
         
-        actual_users = directory_connector.load_users_and_groups(all_groups)
+        actual_users = directory_connector.load_users_and_groups(groups=all_groups)
                 
         tests.helper.assert_equal_users(self, all_users, actual_users)
 

--- a/tests/connector/directory_ldap_test.py
+++ b/tests/connector/directory_ldap_test.py
@@ -9,18 +9,10 @@ import tests.helper
 class LDAPDirectoryTest(unittest.TestCase):
 
     def test_normal(self):
-        user1 = tests.helper.create_test_user(['Acrobat1', 'Acrobat2'])
-        user2 = tests.helper.create_test_user(['Acrobat3'])
+        user1 = tests.helper.create_test_user([])
+        user2 = tests.helper.create_test_user([])
         user3 = tests.helper.create_test_user([])
         all_users = [user1, user2, user3]
-
-        users_by_group = {}
-        for user in all_users:
-            for group in user['groups']:
-                users_with_same_group = users_by_group.get(group)
-                if (users_with_same_group == None):
-                    users_by_group[group] = users_with_same_group = []
-                users_with_same_group.append(user)
 
         ldap_options = {
             'host': 'test_host', 
@@ -43,19 +35,8 @@ class LDAPDirectoryTest(unittest.TestCase):
         def mock_search_s(*args, **kwargs):
             search_result = re.search('cn=(.*?)\)', kwargs['filterstr'])            
             group_name = search_result.group(1)
-            users = users_by_group.get(group_name, [])
-            return [(group_name, {
-                'member': [user['firstname'] for user in users if group_name in user['groups']]
-            })]
+            return [(group_name, {})]
 
-        def mock_result(*args, **kwargs):
-            rtype = ldap.RES_SEARCH_RESULT
-            rdata = []
-            return rtype, rdata
-
-        def mock_search(*args, **kwargs):
-            return kwargs['filterstr']
-    
         def mock_search_ext(*args, **kwargs):
             return kwargs['filterstr']
     
@@ -76,12 +57,10 @@ class LDAPDirectoryTest(unittest.TestCase):
         connection.search_s = mock_search_s
         connection.search_ext = mock_search_ext
         connection.result3 = mock_result3
-        connection.search = mock_search
-        connection.result = mock_result
 
         directory_connector = user_sync.connector.directory.DirectoryConnector(user_sync.connector.directory_ldap)
         directory_connector.initialize(ldap_options)
  
-        actual_users = directory_connector.load_users_and_groups(users_by_group.iterkeys())
+        actual_users = directory_connector.load_users_and_groups(None)
 
         tests.helper.assert_equal_users(self, all_users, actual_users)

--- a/tests/rules_test.py
+++ b/tests/rules_test.py
@@ -40,21 +40,21 @@ class RulesTest(unittest.TestCase):
             directory_group_1: [user_sync.rules.AdobeGroup(primary_group_11, primary_umapi_name), user_sync.rules.AdobeGroup('acrobat12', secondary_1_umapi_name)],
             directory_group_2: [user_sync.rules.AdobeGroup(primary_group_21, primary_umapi_name)]
         }
-        all_users = [tests.helper.create_test_user([directory_group_1]), 
+        everybody = [tests.helper.create_test_user([directory_group_1]),
             tests.helper.create_test_user([directory_group_2]),
             tests.helper.create_test_user([])]
         
-        for user in all_users:
+        for user in everybody:
             user['username'] = user['email']
             user['domain'] = None
             
         primary_users = []
-        primary_user_1 = all_users[1].copy()
+        primary_user_1 = everybody[1].copy()
         primary_user_1['groups'] = [primary_group_11]
         primary_users.append(primary_user_1)
         
-        def mock_load_users_and_groups(groups, extended_attributes=None):
-            return list(all_users)
+        def mock_load_users_and_groups(groups=None, extended_attributes=None, all_users=True):
+            return list(everybody)
         mock_directory_connector = mock.mock.create_autospec(user_sync.connector.directory.DirectoryConnector)
         mock_directory_connector.load_users_and_groups = mock_load_users_and_groups
         
@@ -75,25 +75,25 @@ class RulesTest(unittest.TestCase):
 
         expected_primary_commands_list = []
         
-        user = all_users[1]
+        user = everybody[1]
         commands = tests.helper.create_umapi_commands(user)
         commands.add_groups(set([primary_group_21]))
         commands.remove_groups(set([primary_group_11]))
         expected_primary_commands_list.append(commands)
         
-        user = all_users[0]
+        user = everybody[0]
         commands = tests.helper.create_umapi_commands(user)
         commands.add_user(self.create_user_attributes_for_commands(user, rule_options['update_user_info']))
         commands.add_groups(set([primary_group_11]))
         expected_primary_commands_list.append(commands)
         
-        user = all_users[2]
+        user = everybody[2]
         commands = tests.helper.create_umapi_commands(user)
         commands.add_user(self.create_user_attributes_for_commands(user, rule_options['update_user_info']))
         expected_primary_commands_list.append(commands)
                 
         expected_secondary_commands_list = []
-        user = all_users[0]
+        user = everybody[0]
         commands = tests.helper.create_umapi_commands(user)
         commands.add_groups(set([primary_group_12]))
         expected_secondary_commands_list.append(commands)

--- a/user_sync/app.py
+++ b/user_sync/app.py
@@ -359,6 +359,11 @@ def main():
         if not e.is_reported():
             logger.critical(e.message)
             e.set_reported()
+    except KeyboardInterrupt:
+        try:
+            logger.critical('Keyboard interrupt, exiting immediately.')
+        except:
+            pass
     except:
         try:
             logger.error('Unhandled exception', exc_info=sys.exc_info())

--- a/user_sync/config.py
+++ b/user_sync/config.py
@@ -844,7 +844,7 @@ class OptionsBuilder(object):
     def set_string_value(self, key, default_value):
         """
         :type key: str
-        :type default_value: str
+        :type default_value: Optional(str)
         """
         self.set_value(key, types.StringTypes, default_value)
 

--- a/user_sync/connector/directory.py
+++ b/user_sync/connector/directory.py
@@ -45,12 +45,16 @@ class DirectoryConnector(object):
             options = {}
         self.state = self.implementation.connector_initialize(options)
 
-    def load_users_and_groups(self, groups, extended_attributes=None):
+    def load_users_and_groups(self, groups, extended_attributes=None, all_users=True):
         """
         :type groups: list(str)
-        :type extended_attributes: list(str)
+        :type extended_attributes: Optional(list(str))
+        :type all_users: bool
         :rtype (bool, iterable(dict))
         """
         if extended_attributes is None:
             extended_attributes = []
-        return self.implementation.connector_load_users_and_groups(self.state, groups, extended_attributes)
+        return self.implementation.connector_load_users_and_groups(self.state,
+                                                                   groups=groups,
+                                                                   extended_attributes=extended_attributes,
+                                                                   all_users=all_users)

--- a/user_sync/connector/directory_csv.py
+++ b/user_sync/connector/directory_csv.py
@@ -39,17 +39,16 @@ def connector_initialize(options):
     return state
 
 
-def connector_load_users_and_groups(state, groups, extended_attributes):
+def connector_load_users_and_groups(state, groups=None, extended_attributes=None, all_users=True):
     """
     :type state: CSVDirectoryConnector
-    :type groups: list(str)
-    :type extended_attributes: list(str)
+    :type groups: Optional(list(str))
+    :type extended_attributes: Optional(list(str))
+    :type all_users: bool
     :rtype (bool, iterable(dict))
     """
-
-    # CSV supports arbitrary aka "extended" attrs by default,
-    # so the value of extended_attributes has no impact on this particular connector
-    return state.load_users_and_groups(groups, extended_attributes)
+    # CSV always reads all users, so we don't bother passing the all_users parameter into the implementation
+    return state.load_users_and_groups(groups or [], extended_attributes or [])
 
 
 class CSVDirectoryConnector(object):

--- a/user_sync/identity_type.py
+++ b/user_sync/identity_type.py
@@ -34,8 +34,8 @@ NORMALIZED_IDENTITY_TYPE_MAP = {
 
 def parse_identity_type(value, message_format=None):
     """
-    :type value: str
-    :type message_format: str
+    :type value: basestring
+    :type message_format: basestring
     :rtype str
     """
     result = None

--- a/user_sync/rules.py
+++ b/user_sync/rules.py
@@ -286,10 +286,12 @@ class RuleProcessor(object):
         directory_user_by_user_key = self.directory_user_by_user_key
         filtered_directory_user_by_user_key = self.filtered_directory_user_by_user_key
 
-        directory_groups = set(mappings.iterkeys())
+        directory_groups = set(mappings.iterkeys()) if self.will_manage_groups() else set()
         if directory_group_filter is not None:
             directory_groups.update(directory_group_filter)
-        directory_users = directory_connector.load_users_and_groups(directory_groups, extended_attributes)
+        directory_users = directory_connector.load_users_and_groups(groups=directory_groups,
+                                                                    extended_attributes=extended_attributes,
+                                                                    all_users=directory_group_filter is None)
 
         for directory_user in directory_users:
             user_key = self.get_directory_user_key(directory_user)
@@ -879,6 +881,7 @@ class RuleProcessor(object):
         :param email: (optional) email of the user
         :param id_type: (required) id_type of the user
         :return: string "id_type,username,domain" (or None)
+        :rtype: str
         """
         id_type = user_sync.identity_type.parse_identity_type(id_type)
         email = normalize_string(email) if email else None
@@ -1134,7 +1137,7 @@ class UmapiTargetInfo(object):
     def add_desired_group_for(self, user_key, group):
         """
         :type user_key: str
-        :type group: str
+        :type group: Optional(str)
         """
         desired_groups = self.get_desired_groups(user_key)
         if desired_groups is None:


### PR DESCRIPTION
This changes the LDAP connector functionality to actually query for the members of each group, rather than trying to deduce them from the group membership attributes.

As corollary, this also fixes #129, because we no longer need to read the entire directory in order to make sure we've seen every member of every group.  Since we are querying for the groups directly, we don't have to read the whole directly unless we are directed to.