### PR TITLE
Set domain from email when domain is not specified

### DIFF
--- a/user_sync/connector/directory_ldap.py
+++ b/user_sync/connector/directory_ldap.py
@@ -254,6 +254,8 @@ class LDAPDirectoryConnector(object):
             source_attributes['domain'] = domain
             if domain:
                 user['domain'] = domain
+            elif username != email:
+                user['domain'] = email[email.find('@') + 1:]
             elif last_attribute_name:
                 self.logger.warning('No domain attribute (%s) for user with dn: %s', last_attribute_name, dn)
 


### PR DESCRIPTION
Fix for issue #240 

Look like this feature was implemented for CSV but not LDAP.

I partially tested it up to directory user load part of UST but unable to complete the rest due to lack of Username-Based SSO in my console. 