### PR TITLE
Add feature that allows users to define the log file name.

### DIFF
--- a/examples/config files - basic/1 user-sync-config.yml
+++ b/examples/config files - basic/1 user-sync-config.yml
@@ -217,6 +217,13 @@ logging:
   # If a relative path is specified, it is interpreted relative to this configuration
   # file, not relative to the User Sync process working directory.
   file_log_directory: logs
+  
+  # (optional) file_log_name (default value "default")
+  # The default value will log to a file with the following format "YYYY-MM-DD.log", and
+  # all logging for runs started that day (local time) are placed in that file.
+  # However, this option can be used to always log to a single file i.e. adobesync.log
+  # This method would be preferred for users wanting to use logrotate to manage the log files
+  file_log_name: default
 
   # (optional) file_log_level (default value "info")
   # This determines the detail level of the information logged to files.

--- a/examples/config files - basic/1 user-sync-config.yml
+++ b/examples/config files - basic/1 user-sync-config.yml
@@ -212,8 +212,6 @@ logging:
 
   # (optional) file_log_directory (default value "logs")
   # An absolute or relative path to the directory where log files should be placed.
-  # A single file is created per day, named with format "YYYY-MM-DD.log", and all
-  # logging for runs started on that day (local time) are placed in that file.
   # If a relative path is specified, it is interpreted relative to this configuration
   # file, not relative to the User Sync process working directory.
   file_log_directory: logs

--- a/user_sync/app.py
+++ b/user_sync/app.py
@@ -121,6 +121,7 @@ def init_log(logging_config):
     builder.set_bool_value('log_to_file', False)
     builder.set_string_value('file_log_directory', 'logs')
     builder.set_string_value('file_log_level', 'info')
+    builder.set_string_value('file_log_name', 'default')
     builder.set_string_value('console_log_level', 'info')
     options = builder.get_options()
 
@@ -346,6 +347,7 @@ def main():
     try:
         try:
             args = process_args()
+
         except SystemExit:
             return
 

--- a/user_sync/app.py
+++ b/user_sync/app.py
@@ -148,7 +148,13 @@ def init_log(logging_config):
         if not os.path.exists(file_log_directory):
             os.makedirs(file_log_directory)
 
-        file_path = os.path.join(file_log_directory, datetime.date.today().isoformat() + ".log")
+	file_log_name = "{datestamp}.log".format(datestamp=datetime.date.today().isoformat())
+
+	if options['file_log_name']:
+	    if options['file_log_name'] != 'default':
+	        file_log_name = options['file_log_name']
+
+        file_path = os.path.join(file_log_directory, file_log_name)
         file_handler = logging.FileHandler(file_path)
         file_handler.setLevel(file_log_level)
         file_handler.setFormatter(logging.Formatter(LOG_STRING_FORMAT, LOG_DATE_FORMAT))


### PR DESCRIPTION
I want to use log rotate to handle log rotation for log files of the usersync tool, but log rotate is not very compatible with log files where the log filename is changed daily. I've added an option to allow you to specify a log name or maintain current adobe implementation.

Please accept or deny my proposed changes as deemed appropriate.