### PR TITLE
Escape LDAP special chars

### DIFF
--- a/user_sync/connector/directory_ldap.py
+++ b/user_sync/connector/directory_ldap.py
@@ -178,8 +178,9 @@ class LDAPDirectoryConnector(object):
         base_dn = six.text_type(options['base_dn'])
         group_filter_format = six.text_type(options['group_filter_format'])
         try:
+            filter_string = self.format_ldap_query_string(group_filter_format, group=group)
             res = connection.search_s(base_dn, ldap.SCOPE_SUBTREE,
-                                      filterstr=self.format_ldap_query_string(group_filter_format, group=group), attrsonly=1)
+                                      filterstr=filter_string, attrsonly=1)
         except Exception as e:
             raise AssertionException('Unexpected LDAP failure reading group info: %s' % e)
         group_dn = None
@@ -327,12 +328,13 @@ class LDAPDirectoryConnector(object):
     @staticmethod
     def format_ldap_query_string(query, **kwargs):
         """
-        To be used with any string that will be injected into a LDAP query - this escapes a few special characters that
-        may appear in DNs, group names, etc.
+        Escape LDAP special characters that may appear in injected query strings
+        Should be used with any string that will be injected into an LDAP query.
         :param query:
         :param kwargs:
         :return:
         """
+        # See http://www.rfc-editor.org/rfc/rfc4515.txt
         escape_chars = six.text_type('*()\\&|<>~!:')
         escaped_args = {}
         # kwargs is a dict that would normally be passed to string.format

--- a/user_sync/connector/directory_ldap.py
+++ b/user_sync/connector/directory_ldap.py
@@ -337,12 +337,10 @@ class LDAPDirectoryConnector(object):
         escaped_args = {}
         # kwargs is a dict that would normally be passed to string.format
         for k, v in six.iteritems(kwargs):
-            # python 2 and 3 both support string translation, which would make this process easier
-            # unfortunately, they are not compatible, and six does not provide a wrapper.
-            # additionally, the py2 version does not work with multi-char replacement values
-            # here, we're walking through the format replacement string char by char and replacing
-            # with the escape chars if needed.  since strings are immutable, we build a list of chars
-            # for the escaped string, and join it together after translating the string
+            # LDAP special characters are escaped in the general format '\' + hex(char)
+            # we need to run through the string char by char and if the char exists in
+            # the escape_char list, get the ord of it (decimal ascii value), convert it to hex, and
+            # replace the '0x' with '\'
             escaped_list = []
             for c in v:
                 if c in escape_chars:

--- a/user_sync/connector/directory_ldap.py
+++ b/user_sync/connector/directory_ldap.py
@@ -333,12 +333,7 @@ class LDAPDirectoryConnector(object):
         :param kwargs:
         :return:
         """
-        escape_chars = {
-            six.text_type('*'):  six.text_type('\\2A'),
-            six.text_type('('):  six.text_type('\\28'),
-            six.text_type(')'):  six.text_type('\\29'),
-            six.text_type('\\'): six.text_type('\\5C'),
-        }
+        escape_chars = six.text_type('*()\\&|<>~!:')
         escaped_args = {}
         # kwargs is a dict that would normally be passed to string.format
         for k, v in six.iteritems(kwargs):
@@ -349,15 +344,10 @@ class LDAPDirectoryConnector(object):
             # with the escape chars if needed.  since strings are immutable, we build a list of chars
             # for the escaped string, and join it together after translating the string
             escaped_list = []
-            replace = six.text_type('')
             for c in v:
-                for s, r in six.iteritems(escape_chars):
-                    if c == s:
-                        replace = r
-                        break
-                if replace:
+                if c in escape_chars:
+                    replace = six.text_type(hex(ord(c))).replace('0x', '\\')
                     escaped_list.append(replace)
-                    replace = six.text_type('')
                 else:
                     escaped_list.append(c)
             escaped_args[k] = six.text_type('').join(escaped_list)


### PR DESCRIPTION
LDAP defines a number of special characters that must be escaped in LDAP queries:

http://www.rfc-editor.org/rfc/rfc4515.txt

The sync tool must escape any of these special characters that may be present in group names, group DNs, or anywhere else we use `string.format()` to inject dynamic values into the UST's LDAP queries.

This patch should resolve that issue.  I've tested it with special characters in group names as well as in OUs that contain groups (which shows up in the group DN).