### PR TITLE
Added Feature: Two-Steps group membership lookup

### DIFF
--- a/examples/config files - basic/3 connector-ldap.yml
+++ b/examples/config files - basic/3 connector-ldap.yml
@@ -81,17 +81,16 @@ group_filter_format: "(&(|(objectCategory=group)(objectClass=groupOfNames)(objec
 # group_member_filter_format: "(memberOf:1.2.840.113556.1.4.1941:={group_dn})"
 group_member_filter_format: "(memberOf={group_dn})"
 
-# (optional) two_steps_group_member_attribute_name: (no default)
-# two-step group member attribute name is required for two steps lookup to know which
-# attribute within a group object contained group membership value.
-# two steps group member lookup should only be used for the directory system that
-# does not support memberOf or equivalent virtual attribute. Two steps lookup allows
-# user sync tool pull group membership from group object and does a secondary
-# lookup of user object based on group membership value.
-# the value of the specified attribute should return a distinguishName of a user.
-# Note: Depending on the size of your directory, this process might take longer.
-#       group_member_filter_format must not be defined when using this option.
-#two_steps_group_member_attribute_name: "member"
+# (optional) group_member_attribute_name (no default)
+# If your LDAP system doesn't support queries using memberOf predicates,
+# you should undefine the group_member_filter_format and instead define
+# the group_member_attribute _name.  The defined value should be the
+# attribute on the group whose multi-values are the distinguished names
+# of the group members.  When group_member_attribute_name is defined,
+# User Sync will look up group members by querying your groups to find
+# the DNs of their members, and then removing any of those members
+# who do not meet the criteria of the all_users_filter.
+#group_member_attribute_name: "member"
 
 # (optional) string_encoding (default value given below)
 # string_encoding specifies the Unicode string encoding used by the directory.

--- a/examples/config files - basic/3 connector-ldap.yml
+++ b/examples/config files - basic/3 connector-ldap.yml
@@ -84,7 +84,7 @@ group_member_filter_format: "(memberOf={group_dn})"
 # (optional) group_member_attribute_name (no default)
 # If your LDAP system doesn't support queries using memberOf predicates,
 # you should undefine the group_member_filter_format and instead define
-# the group_member_attribute _name.  The defined value should be the
+# the group_member_attribute_name.  The defined value should be the
 # attribute on the group whose multi-values are the distinguished names
 # of the group members.  When group_member_attribute_name is defined,
 # User Sync will look up group members by querying your groups to find

--- a/examples/config files - basic/3 connector-ldap.yml
+++ b/examples/config files - basic/3 connector-ldap.yml
@@ -81,6 +81,18 @@ group_filter_format: "(&(|(objectCategory=group)(objectClass=groupOfNames)(objec
 # group_member_filter_format: "(memberOf:1.2.840.113556.1.4.1941:={group_dn})"
 group_member_filter_format: "(memberOf={group_dn})"
 
+# (optional) two_steps_group_member_attribute_name: (no default)
+# two-step group member attribute name is required for two steps lookup to know which
+# attribute within a group object contained group membership value.
+# two steps group member lookup should only be used for the directory system that
+# does not support memberOf or equivalent virtual attribute. Two steps lookup allows
+# user sync tool pull group membership from group object and does a secondary
+# lookup of user object based on group membership value.
+# the value of the specified attribute should return a distinguishName of a user.
+# Note: Depending on the size of your directory, this process might take longer.
+#       group_member_filter_format must not be defined when using this option.
+#two_steps_group_member_attribute_name: "member"
+
 # (optional) string_encoding (default value given below)
 # string_encoding specifies the Unicode string encoding used by the directory.
 # All values retrieved from the directory are converted to Unicode before being

--- a/user_sync/connector/directory_ldap.py
+++ b/user_sync/connector/directory_ldap.py
@@ -68,9 +68,9 @@ class LDAPDirectoryConnector(object):
             '(&(|(objectCategory=group)(objectClass=groupOfNames)(objectClass=posixGroup))(cn={group}))'))
         builder.set_string_value('all_users_filter', six.text_type(
             '(&(objectClass=user)(objectCategory=person)(!(userAccountControl:1.2.840.113556.1.4.803:=2)))'))
-        builder.set_string_value('group_member_filter_format', six.text_type(
-            '(memberOf={group_dn})'))
+        builder.set_string_value('group_member_filter_format', None)
         builder.set_bool_value('require_tls_cert', False)
+        builder.set_string_value('two_steps_group_member_attribute_name', None)
         builder.set_string_value('string_encoding', 'utf8')
         builder.set_string_value('user_identity_type_format', None)
         builder.set_string_value('user_email_format', six.text_type('{mail}'))
@@ -86,6 +86,18 @@ class LDAPDirectoryConnector(object):
         username = builder.require_string_value('username')
         builder.require_string_value('base_dn')
         options = builder.get_options()
+
+        two_steps_lookup = False
+
+        if not options['two_steps_group_member_attribute_name'] and not options['group_member_filter_format']:
+            options['group_member_filter_format'] = six.text_type('(memberOf={group_dn})')
+        elif options['two_steps_group_member_attribute_name'] and options['group_member_filter_format']:
+            raise AssertionException(
+                'Cannot define both two_steps_group_member_attribute_name and group_member_filter_format in config')
+        elif options['two_steps_group_member_attribute_name']:
+            two_steps_lookup = True
+
+        self.two_steps_lookup = two_steps_lookup
         self.options = options
         self.logger = logger = user_sync.connector.helper.create_logger(options)
         logger.debug('%s initialized with options: %s', self.name, options)
@@ -132,35 +144,52 @@ class LDAPDirectoryConnector(object):
         options = self.options
         all_users_filter = six.text_type(options['all_users_filter'])
         group_member_filter_format = six.text_type(options['group_member_filter_format'])
+        two_steps_group_member_attribute_name = six.text_type(options['two_steps_group_member_attribute_name'])
+        two_steps_lookup = self.two_steps_lookup
+
+        # save all the users to memory for faster 2-steps lookup process
+        if all_users or two_steps_lookup:
+            all_users_records = dict(self.iter_users(all_users_filter, extended_attributes))
 
         # for each group that's required, do one search for the users of that group
         for group in groups:
-            group_dn = self.find_ldap_group_dn(group)
-            if not group_dn:
-                self.logger.warning("No group found for: %s", group)
-                continue
-            group_member_subfilter = self.format_ldap_query_string(group_member_filter_format, group_dn=group_dn)
-            if not group_member_subfilter.startswith('('):
-                group_member_subfilter = six.text_type('(') + group_member_subfilter + six.text_type(')')
-            user_subfilter = all_users_filter
-            if not user_subfilter.startswith('('):
-                user_subfilter = six.text_type('(') + user_subfilter + six.text_type(')')
-            group_user_filter = six.text_type('(&') + group_member_subfilter + user_subfilter + six.text_type(')')
             group_users = 0
-            try:
-                for user_dn, user in self.iter_users(group_user_filter, extended_attributes):
-                    user['groups'].append(group)
-                    group_users += 1
-                self.logger.debug('Count of users in group "%s": %d', group, group_users)
-            except Exception as e:
-                raise AssertionException('Unexpected LDAP failure reading group members: %s' % e)
+            if not two_steps_lookup:
+                group_dn = self.find_group_dn(group)
+                if not group_dn:
+                    self.logger.warning("No group found for: %s", group)
+                    continue
+                group_member_subfilter = self.format_ldap_query_string(group_member_filter_format, group_dn=group_dn)
+                if not group_member_subfilter.startswith('('):
+                    group_member_subfilter = six.text_type('(') + group_member_subfilter + six.text_type(')')
+                user_subfilter = all_users_filter
+                if not user_subfilter.startswith('('):
+                    user_subfilter = six.text_type('(') + user_subfilter + six.text_type(')')
+                group_user_filter = six.text_type('(&') + group_member_subfilter + user_subfilter + six.text_type(')')
+                try:
+                    for user_dn, user in self.iter_users(group_user_filter, extended_attributes):
+                        user['groups'].append(group)
+                        group_users += 1
+                except Exception as e:
+                    raise AssertionException('Unexpected LDAP failure reading group members: %s' % e)
+            else:
+                try:
+                    members = self.find_group_member_dn(group, two_steps_group_member_attribute_name)
+                    for member in members:
+                        user = all_users_records.get(member)
+                        if user:
+                            user['groups'].append(group)
+                            group_users += 1
+                except Exception as e:
+                    raise AssertionException('Unexpected LDAP failure reading group members: %s' % e)
+            self.logger.debug('Count of users in group "%s": %d', group, group_users)
 
         # if all users are requested, do an additional search for all of them
         if all_users:
             ungrouped_users = 0
             grouped_users = 0
             try:
-                for user_dn, user in self.iter_users(all_users_filter, extended_attributes):
+                for user_dn, user in all_users_records.iteritems():
                     if not user['groups']:
                         ungrouped_users += 1
                     else:
@@ -171,10 +200,16 @@ class LDAPDirectoryConnector(object):
             except Exception as e:
                 raise AssertionException('Unexpected LDAP failure reading all users: %s' % e)
 
+        #Do a cleanup if two_steps enabled but not all_users
+        if two_steps_lookup and not all_users:
+            for member in all_users_records:
+                if member in self.user_by_dn and len(self.user_by_dn[member]['groups']) == 0:
+                    del self.user_by_dn[member]
+
         self.logger.debug('Total users loaded: %d', len(self.user_by_dn))
         return six.itervalues(self.user_by_dn)
 
-    def find_ldap_group_dn(self, group):
+    def find_group_dn(self, group):
         """
         :type group: str
         :rtype str
@@ -196,6 +231,32 @@ class LDAPDirectoryConnector(object):
                     raise AssertionException("Multiple LDAP groups found for: %s" % group)
                 group_dn = current_tuple[0]
         return group_dn
+
+    def find_group_member_dn(self, group, member_attribute):
+        """
+        :type group: str
+        :type member_attribute: str
+        :rtype list
+        """
+        connection = self.connection
+        options = self.options
+        base_dn = six.text_type(options['base_dn'])
+        group_filter_format = six.text_type(options['group_filter_format'])
+        try:
+            filter_string = self.format_ldap_query_string(group_filter_format, group=group)
+            res = connection.search_s(base_dn, ldap.SCOPE_SUBTREE,
+                                      filterstr=filter_string, attrlist=[member_attribute])
+        except Exception as e:
+            raise AssertionException('Unexpected LDAP failure reading group info: %s' % e)
+        group_dn = None
+        for current_tuple in res:
+            if current_tuple[0]:
+                if group_dn:
+                    raise AssertionException("Multiple LDAP groups found for: %s" % group)
+                group_dn = current_tuple[0]
+                if member_attribute in current_tuple[1]:
+                    for member in current_tuple[1][member_attribute]:
+                        yield member
 
     def iter_users(self, users_filter, extended_attributes):
         options = self.options

--- a/user_sync/connector/directory_ldap.py
+++ b/user_sync/connector/directory_ldap.py
@@ -178,7 +178,7 @@ class LDAPDirectoryConnector(object):
         # if all users are requested, count number of users without group assignment
         if all_users:
             ungrouped_users = 0
-            for user_dn, user in all_users_records.iteritems():
+            for user_dn, user in six.iteritems(all_users_records):
                 if not user['groups']:
                     ungrouped_users += 1
             if groups:
@@ -240,7 +240,7 @@ class LDAPDirectoryConnector(object):
                 group_dn = current_tuple[0]
                 if member_attribute in current_tuple[1]:
                     for member in current_tuple[1][member_attribute]:
-                        yield six.text_type(member)
+                        yield member.decode('utf-8')
 
     def iter_users(self, users_filter, extended_attributes):
         options = self.options


### PR DESCRIPTION
New feature: two-steps group membership lookup for unsupported memberOf virtual attribute on LDAP server.

I still need to work on documentation.

Resolve issue #323