### PR TITLE
Additional group discovery and creation

### DIFF
--- a/docs/en/user-manual/advanced_configuration.md
+++ b/docs/en/user-manual/advanced_configuration.md
@@ -785,6 +785,8 @@ following conditions are true:
 
 1. Group is targeted for at least one user
 2. Group does not currently exist
+3. The `--process-groups` command argument is set (or the equivalent
+   invocation option)
 
 New groups are always created as user groups.  The UMAPI does not
 support product profile creation, so the Sync Tool can't create them.

--- a/examples/config files - basic/1 user-sync-config.yml
+++ b/examples/config files - basic/1 user-sync-config.yml
@@ -214,14 +214,12 @@ directory_users:
   # auto_create:
   #   Automatically create target groups that do not exist.  Non-existent groups
   #   will *always* be created as Adobe groups.  If targeting product profiles, they
-  #   must always be created manually in the Admin Console
-  # auto_delete:
-  #   Automatically delete user groups that don't have any members at the time of sync.
-  #   The only groups considered for deletion are groups mapped in the renaming rules
-  #   specified in additional_groups.
+  #   must always be created manually in the Admin Console.
+  #   NOTE: auto_create applies to any targeted Adobe group that doesn't exist.
+  #         This includes groups targeted through group mapping, extension config,
+  #         and the additional_groups functionality.
   # group_sync_options:
   #   auto_create: False
-  #   auto_delete: False
 
 # The limits section provides processing limits which can help ensure that
 # User Sync jobs do not exceed expected guardrails in their operation

--- a/examples/config files - basic/1 user-sync-config.yml
+++ b/examples/config files - basic/1 user-sync-config.yml
@@ -167,13 +167,10 @@ directory_users:
     # is specified as a list of entries, each of which has a directory_group
     # setting (whose value is a single directory group) and an adobe_groups
     # setting (whose value is a list of 0 or more product configuration and
-    # user groups).  All of the values in the adobe_groups settings must
-    # match the name of product configurations and user groups which have
-    # already been created on the Adobe side.  (In this example, we pretend
-    # that "Acrobat DC Pro" is a product configuration and "Copy Editors"
-    # is a user group that the you have already created.  Possibly
-    # the "Copy Editors" user group has been assigned access to appropriate
-    # Adobe products, such as InDesign and InCopy.)
+    # user groups).  In this example, imagine that "Acrobat DC Pro" is a
+    # product configuration and "Copy Editors" is a user group, and that
+    # the "Copy Editors" user group will be assigned access to appropriate
+    # Adobe products, such as InDesign and InCopy.
     # [You will need to edit or remove these examples.]
     - directory_group: "Finance"
       adobe_groups:
@@ -185,6 +182,33 @@ directory_users:
       adobe_groups:
         - "Copy Editors"
         - "Acrobat DC Pro"
+
+  # (optional) additional_groups (no default value)
+  # People who use their directory groups for ACLs on the Adobe side
+  # often have a very large number of groups that they want mapped
+  # over to (user) groups on the Adobe side.  To avoid having to
+  # specify those groups statically in their config file, and to
+  # update their config file when they change, they can instead
+  # use a naming convention for the groups and specify that here.
+  # The value of this attribute is a mapping from Python regular expressions
+  # that specify directory groups of interest to Pythonn replacement expressions
+  # that specify how to construct the name of the target Adobe group
+  # that the directory group should be mapped to.  If a value is
+  # provided, then all users who are (directly) in groups whose
+  # CN matches one of the source regular expressions will be put in a user group
+  # on the Adobe side whose name is given by the target replacement expression.
+  # The simple example here (which should be removed) maps all the
+  # groups that start with "ACL-" or end with "-ACL" to an Adobe
+  # group that starts with "ACL-Grp-".
+  # (All of these regular expressions must match the entire group name.
+  # For details on Python regular expression matching and replacement,
+  # see https://docs.python.org/howto/regex.html )
+  additional_groups:
+    - source: "ACL-(.+)"
+      target: "ACL-Grp-(\1)"
+    - source: "(.+)-ACL"
+      target: "ACL-Grp-(\1)"
+
 
 # The limits section provides processing limits which can help ensure that
 # User Sync jobs do not exceed expected guardrails in their operation

--- a/examples/config files - basic/1 user-sync-config.yml
+++ b/examples/config files - basic/1 user-sync-config.yml
@@ -191,7 +191,7 @@ directory_users:
   # update their config file when they change, they can instead
   # use a naming convention for the groups and specify that here.
   # The value of this attribute is a mapping from Python regular expressions
-  # that specify directory groups of interest to Pythonn replacement expressions
+  # that specify directory groups of interest to Python replacement expressions
   # that specify how to construct the name of the target Adobe group
   # that the directory group should be mapped to.  If a value is
   # provided, then all users who are (directly) in groups whose

--- a/examples/config files - basic/1 user-sync-config.yml
+++ b/examples/config files - basic/1 user-sync-config.yml
@@ -209,6 +209,19 @@ directory_users:
   #   - source: "(.+)-ACL"
   #     target: "ACL-Grp-(\1)"
 
+  # (optional) group_sync_options (default: all options false)
+  # Options that govern the automatic creation and/or deletion of Adobe user groups
+  # auto_create:
+  #   Automatically create target groups that do not exist.  Non-existent groups
+  #   will *always* be created as Adobe groups.  If targeting product profiles, they
+  #   must always be created manually in the Admin Console
+  # auto_delete:
+  #   Automatically delete user groups that don't have any members at the time of sync.
+  #   The only groups considered for deletion are groups mapped in the renaming rules
+  #   specified in additional_groups.
+  # group_sync_options:
+  #   auto_create: False
+  #   auto_delete: False
 
 # The limits section provides processing limits which can help ensure that
 # User Sync jobs do not exceed expected guardrails in their operation

--- a/examples/config files - basic/1 user-sync-config.yml
+++ b/examples/config files - basic/1 user-sync-config.yml
@@ -203,11 +203,11 @@ directory_users:
   # (All of these regular expressions must match the entire group name.
   # For details on Python regular expression matching and replacement,
   # see https://docs.python.org/howto/regex.html )
-  additional_groups:
-    - source: "ACL-(.+)"
-      target: "ACL-Grp-(\1)"
-    - source: "(.+)-ACL"
-      target: "ACL-Grp-(\1)"
+  # additional_groups:
+  #   - source: "ACL-(.+)"
+  #     target: "ACL-Grp-(\1)"
+  #   - source: "(.+)-ACL"
+  #     target: "ACL-Grp-(\1)"
 
 
 # The limits section provides processing limits which can help ensure that

--- a/examples/config files - basic/1 user-sync-config.yml
+++ b/examples/config files - basic/1 user-sync-config.yml
@@ -218,6 +218,8 @@ directory_users:
   #   NOTE: auto_create applies to any targeted Adobe group that doesn't exist.
   #         This includes groups targeted through group mapping, extension config,
   #         and the additional_groups functionality.
+  #   The --process-groups command argument or equivalent invocation setting must
+  #   be enabled for groups to be auto-created
   # group_sync_options:
   #   auto_create: False
 

--- a/examples/config files - basic/3 connector-ldap.yml
+++ b/examples/config files - basic/3 connector-ldap.yml
@@ -84,18 +84,6 @@ group_member_filter_format: "(memberOf={group_dn})"
 # only users that would be selected by that filter will be returned as
 # members of the given group.
 
-# (optional) member_group_filter_format (default value given below)
-# member_group_filter_format specifies the query used to find all groups that
-# directly contain a given member.  The string {member_dn} is replaced
-# with the DN of the group member.  The string {member_uid) is replaced with
-# the uid attribute of the group member, if any.  The default value expects
-# groups to refer to members by their DN.  For groups that refer to their
-# members by their UID (e.g., posix groups in many OpenLDAP systems), you
-# probably want to use this value instead: "(memberUid={member_uid})"
-# Note that this filter is &-combined with the group_filter_format query
-# specifying a wildcard for the group name.  So it will only find groups.
-# member_group_filter_format: "(member={member_dn})"
-
 # (optional) string_encoding (default value given below)
 # string_encoding specifies the Unicode string encoding used by the directory.
 # All values retrieved from the directory are converted to Unicode before being

--- a/examples/config files - basic/3 connector-ldap.yml
+++ b/examples/config files - basic/3 connector-ldap.yml
@@ -72,7 +72,7 @@ all_users_filter: "(&(objectClass=user)(objectCategory=person)(!(userAccountCont
 group_filter_format: "(&(|(objectCategory=group)(objectClass=groupOfNames)(objectClass=posixGroup))(cn={group}))"
 
 # (optional) group_member_filter_format (default value given below)
-# group_users_filter specifies the query used to find all members of a group,
+# group_member_filter_format specifies the query used to find all members of a group,
 # where the string {group_dn} is replaced with the group distinguished name.
 # The default value just finds users who are immediate members of the group,
 # not those who are "indirectly" members by virtue of membership in a group
@@ -80,6 +80,21 @@ group_filter_format: "(&(|(objectCategory=group)(objectClass=groupOfNames)(objec
 # use this value instead of the default:
 # group_member_filter_format: "(memberOf:1.2.840.113556.1.4.1941:={group_dn})"
 group_member_filter_format: "(memberOf={group_dn})"
+# Note that this filter is &-combined with the all_users_filter so that
+# only users that would be selected by that filter will be returned as
+# members of the given group.
+
+# (optional) member_group_filter_format (default value given below)
+# member_group_filter_format specifies the query used to find all groups that
+# directly contain a given member.  The string {member_dn} is replaced
+# with the DN of the group member.  The string {member_uid) is replaced with
+# the uid attribute of the group member, if any.  The default value expects
+# groups to refer to members by their DN.  For groups that refer to their
+# members by their UID (e.g., posix groups in many OpenLDAP systems), you
+# probably want to use this value instead: "(memberUid={member_uid})"
+member_group_filter_format: "(member={member_dn})"
+# Note that this filter is &-combined with the group_filter_format query
+# specifying a wildcard for the group name.  So it will only find groups.
 
 # (optional) string_encoding (default value given below)
 # string_encoding specifies the Unicode string encoding used by the directory.
@@ -172,14 +187,9 @@ user_email_format: "{mail}"
 # are already pre-defined attribute names that are used for these fields:
 # - the Adobe first name is set from the LDAP "givenName" attribute
 # - the Adobe last name is set from the LDAP "sn" (surname) attribute
-# - the Adobe country is set from the LDAP "country" attribute
+# - the Adobe country is set from the LDAP "c" (country) attribute
 # If you need to override these values on the Adobe side, you can use the
 # custom extension mechanism (see the docs) to compute and set field values
-# by combining these and any other custom attributes needed.  Seed the
+# by combining these and any other custom attributes needed.  See the
 # User Sync documentation for full details.
-#
-# Finally, some LDAP systems use uids to identify groups, and place users in
-# groups via uid rather than name.  The User Sync implementation always reads
-# the uid attribute on all objects if the directory provides one, so it is
-# able to handle directories which function in this way even though the
-# configuration files always specify groups by name.
+

--- a/examples/config files - basic/3 connector-ldap.yml
+++ b/examples/config files - basic/3 connector-ldap.yml
@@ -92,7 +92,7 @@ group_member_filter_format: "(memberOf={group_dn})"
 # groups to refer to members by their DN.  For groups that refer to their
 # members by their UID (e.g., posix groups in many OpenLDAP systems), you
 # probably want to use this value instead: "(memberUid={member_uid})"
-member_group_filter_format: "(member={member_dn})"
+# member_group_filter_format: "(member={member_dn})"
 # Note that this filter is &-combined with the group_filter_format query
 # specifying a wildcard for the group name.  So it will only find groups.
 

--- a/examples/config files - basic/3 connector-ldap.yml
+++ b/examples/config files - basic/3 connector-ldap.yml
@@ -92,9 +92,9 @@ group_member_filter_format: "(memberOf={group_dn})"
 # groups to refer to members by their DN.  For groups that refer to their
 # members by their UID (e.g., posix groups in many OpenLDAP systems), you
 # probably want to use this value instead: "(memberUid={member_uid})"
-# member_group_filter_format: "(member={member_dn})"
 # Note that this filter is &-combined with the group_filter_format query
 # specifying a wildcard for the group name.  So it will only find groups.
+# member_group_filter_format: "(member={member_dn})"
 
 # (optional) string_encoding (default value given below)
 # string_encoding specifies the Unicode string encoding used by the directory.

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(name='user-sync',
           'pyldap==2.4.45',
           'PyYAML',
           'six',
-          'umapi-client>=2.10',
+          'umapi-client>=2.11',
       ],
       extras_require={
           ':sys_platform=="linux" or sys_platform=="linux2"':[

--- a/user_sync/app.py
+++ b/user_sync/app.py
@@ -308,8 +308,9 @@ def begin_work(config_loader):
         directory_connector.initialize(directory_connector_options)
 
     additional_group_filters = None
-    if rule_config['directory_additional_groups'] and isinstance(rule_config['directory_additional_groups'], list):
-        additional_group_filters = [r['source'] for r in rule_config['directory_additional_groups']]
+    additional_groups = rule_config.get('additional_groups', None)
+    if additional_groups and isinstance(additional_groups, list):
+        additional_group_filters = [r['source'] for r in additional_groups]
 
     directory_connector.state.additional_group_filters = additional_group_filters
 

--- a/user_sync/app.py
+++ b/user_sync/app.py
@@ -307,6 +307,12 @@ def begin_work(config_loader):
             directory_connector_options['user_identity_type'] = rule_config['new_account_type']
         directory_connector.initialize(directory_connector_options)
 
+    additional_group_filters = None
+    if rule_config['directory_additional_groups'] and isinstance(rule_config['directory_additional_groups'], list):
+        additional_group_filters = [r['source'] for r in rule_config['directory_additional_groups']]
+
+    directory_connector.state.additional_group_filters = additional_group_filters
+
     primary_name = '.primary' if secondary_umapi_configs else ''
     umapi_primary_connector = user_sync.connector.umapi.UmapiConnector(primary_name, primary_umapi_config)
     umapi_other_connectors = {}

--- a/user_sync/config.py
+++ b/user_sync/config.py
@@ -444,6 +444,7 @@ class ConfigLoader(object):
         options.update(self.invocation_options)
 
         # process directory configuration options
+        new_account_type = None
         directory_config = self.main_config.get_dict_config('directory_users', True)
         if directory_config:
             # account type
@@ -457,6 +458,12 @@ class ConfigLoader(object):
             default_country_code = directory_config.get_string('default_country_code', True)
             if default_country_code:
                 options['default_country_code'] = default_country_code
+            additional_groups = directory_config.get_list('additional_groups', True) or []
+            additional_groups = [{'source': re.compile(r['source']), 'target': r['target']} for r in additional_groups]
+            options['additional_groups'] = additional_groups
+        if not new_account_type:
+            new_account_type = user_sync.identity_type.ENTERPRISE_IDENTITY_TYPE
+            self.logger.debug("Using default for new_account_type: %s", new_account_type)
 
         # process exclusion configuration options
         adobe_config = self.main_config.get_dict_config('adobe_users', True)

--- a/user_sync/config.py
+++ b/user_sync/config.py
@@ -461,10 +461,7 @@ class ConfigLoader(object):
             additional_groups = directory_config.get_list('additional_groups', True) or []
             additional_groups = [{'source': re.compile(r['source']), 'target': r['target']} for r in additional_groups]
             options['additional_groups'] = additional_groups
-            sync_options = directory_config.get_dict_config('groups_sync_options', True)
-            if sync_options:
-                options['auto_create'] = sync_options.get_bool('auto_create', True)
-            sync_options = directory_config.get_dict_config('groups_sync_options', True)
+            sync_options = directory_config.get_dict_config('group_sync_options', True)
             if sync_options:
                 options['auto_create'] = sync_options.get_bool('auto_create', True)
         if not new_account_type:

--- a/user_sync/config.py
+++ b/user_sync/config.py
@@ -464,6 +464,9 @@ class ConfigLoader(object):
             sync_options = directory_config.get_dict_config('groups_sync_options', True)
             if sync_options:
                 options['auto_create'] = sync_options.get_bool('auto_create', True)
+            sync_options = directory_config.get_dict_config('groups_sync_options', True)
+            if sync_options:
+                options['auto_create'] = sync_options.get_bool('auto_create', True)
         if not new_account_type:
             new_account_type = user_sync.identity_type.ENTERPRISE_IDENTITY_TYPE
             self.logger.debug("Using default for new_account_type: %s", new_account_type)

--- a/user_sync/config.py
+++ b/user_sync/config.py
@@ -461,6 +461,9 @@ class ConfigLoader(object):
             additional_groups = directory_config.get_list('additional_groups', True) or []
             additional_groups = [{'source': re.compile(r['source']), 'target': r['target']} for r in additional_groups]
             options['additional_groups'] = additional_groups
+            sync_options = directory_config.get_dict_config('groups_sync_options', True)
+            if sync_options:
+                options['auto_create'] = sync_options.get_bool('auto_create', True)
         if not new_account_type:
             new_account_type = user_sync.identity_type.ENTERPRISE_IDENTITY_TYPE
             self.logger.debug("Using default for new_account_type: %s", new_account_type)

--- a/user_sync/connector/directory_ldap.py
+++ b/user_sync/connector/directory_ldap.py
@@ -318,6 +318,12 @@ class LDAPDirectoryConnector(object):
             yield (dn, user)
 
     def get_member_groups(self, user):
+        """
+        Get a list of member group common names for user
+        Assumes groups are contained in attribute memberOf
+        :param user:
+        :return:
+        """
         group_names = []
         groups = LDAPValueFormatter.get_attribute_value(user, 'memberOf')
         for group_dn in map(dn.str2dn, groups):
@@ -328,6 +334,13 @@ class LDAPDirectoryConnector(object):
 
     @staticmethod
     def get_cn_from_dn(group_dn):
+        """
+        Take a DN parsed by ldap.dn.str2dn and locate and return the common name
+        Returns None if no common name is found
+        If common name is complex (e.g. cn=Bob Jones+email=bob.jones@example.com) then first part of CN is returned
+        :param group_dn:
+        :return:
+        """
         for rdn in group_dn:
             for rdn_part in rdn:
                 if rdn_part[0].lower() == 'cn':

--- a/user_sync/connector/directory_ldap.py
+++ b/user_sync/connector/directory_ldap.py
@@ -289,6 +289,10 @@ class LDAPDirectoryConnector(object):
             elif last_attribute_name:
                 self.logger.warning('No country code attribute (%s) for user with dn: %s', last_attribute_name, dn)
 
+            uid_value = LDAPValueFormatter.get_attribute_value(record, six.text_type('uid'))
+            source_attributes['uid'] = uid_value
+            user['member_groups'] = find_member_groups(dn, uid_value if uid_value else six.text_type(''))
+
             if extended_attributes is not None:
                 for extended_attribute in extended_attributes:
                     extended_attribute_value = LDAPValueFormatter.get_attribute_value(record, extended_attribute)

--- a/user_sync/connector/directory_ldap.py
+++ b/user_sync/connector/directory_ldap.py
@@ -294,6 +294,7 @@ class LDAPDirectoryConnector(object):
             uid_value = LDAPValueFormatter.get_attribute_value(record, six.text_type('uid'))
             source_attributes['uid'] = uid_value
 
+            user['member_groups'] = []
             if self.additional_group_filters:
                 member_groups = []
                 for f in self.additional_group_filters:

--- a/user_sync/connector/directory_ldap.py
+++ b/user_sync/connector/directory_ldap.py
@@ -322,7 +322,7 @@ class LDAPDirectoryConnector(object):
                                                       member_uid=uid)
         base_dn = six.text_type(self.options['base_dn'])
         res = self.connection.search_s(base_dn, ldap.SCOPE_SUBTREE,
-                                  filterstr=member_filter, attrlist=['cn'])
+                                  filterstr=member_filter)
         member_groups = []
         for _, group_rec in res:
             if isinstance(group_rec, dict):

--- a/user_sync/connector/directory_ldap.py
+++ b/user_sync/connector/directory_ldap.py
@@ -316,12 +316,13 @@ class LDAPDirectoryConnector(object):
             yield (dn, user)
 
     def find_member_groups(self, dn, uid):
-        member_filter = self.format_ldap_query_string(self.options['member_group_filter_format'],
+        member_group_filter_format = six.text_type(self.options['member_group_filter_format'])
+        member_filter = self.format_ldap_query_string(member_group_filter_format,
                                                       member_dn=dn,
                                                       member_uid=uid)
         base_dn = six.text_type(self.options['base_dn'])
         res = self.connection.search_s(base_dn, ldap.SCOPE_SUBTREE,
-                                  filterstr=member_filter, attrlist=['cn'])
+                                  filterstr=member_filter)
         member_groups = []
         for _, group_rec in res:
             if isinstance(group_rec, dict):

--- a/user_sync/connector/directory_ldap.py
+++ b/user_sync/connector/directory_ldap.py
@@ -71,7 +71,6 @@ class LDAPDirectoryConnector(object):
             '(&(objectClass=user)(objectCategory=person)(!(userAccountControl:1.2.840.113556.1.4.803:=2)))'))
         builder.set_string_value('group_member_filter_format', six.text_type(
             '(memberOf={group_dn})'))
-        builder.set_string_value('member_group_filter_format', None)
         builder.set_bool_value('require_tls_cert', False)
         builder.set_string_value('string_encoding', 'utf8')
         builder.set_string_value('user_identity_type_format', None)

--- a/user_sync/connector/directory_ldap.py
+++ b/user_sync/connector/directory_ldap.py
@@ -322,7 +322,7 @@ class LDAPDirectoryConnector(object):
                                                       member_uid=uid)
         base_dn = six.text_type(self.options['base_dn'])
         res = self.connection.search_s(base_dn, ldap.SCOPE_SUBTREE,
-                                  filterstr=member_filter)
+                                  filterstr=member_filter, attrlist=['cn'])
         member_groups = []
         for _, group_rec in res:
             if isinstance(group_rec, dict):

--- a/user_sync/connector/umapi.py
+++ b/user_sync/connector/umapi.py
@@ -166,10 +166,11 @@ class UmapiConnector(object):
         except umapi_client.UnavailableError as e:
             raise AssertionException("Error contacting UMAPI server: %s" % e)
 
-    def create_group(self,name):
+    def create_group(self, name):
         if name:
-            ug = umapi_client.UserGroups(self.connection)
-            ug.create(name, 'Automatically created by User Sync Tool')
+            group = umapi_client.UserGroupAction(group_name=name)
+            group.create(description="Automatically created by User Sync Tool")
+            return self.connection.execute_single(group)
 
     def get_action_manager(self):
         return self.action_manager

--- a/user_sync/connector/umapi.py
+++ b/user_sync/connector/umapi.py
@@ -146,6 +146,20 @@ class UmapiConnector(object):
         except umapi_client.UnavailableError as e:
             raise AssertionException("Error contacting UMAPI server: %s" % e)
 
+    def get_groups(self):
+        return list(self.iter_groups())
+
+    def iter_groups(self):
+        try:
+            for g in umapi_client.UserGroupsQuery(self.connection):
+                yield g
+        except umapi_client.UnavailableError as e:
+            raise AssertionException("Error contacting UMAPI server: %s" % e)
+
+    def create_group(self,name):
+        if name:
+            ug = umapi_client.UserGroups(self.connection)
+            ug.create(name, 'Automatically created by User Sync Tool')
     def get_action_manager(self):
         return self.action_manager
 

--- a/user_sync/connector/umapi.py
+++ b/user_sync/connector/umapi.py
@@ -156,6 +156,16 @@ class UmapiConnector(object):
         except umapi_client.UnavailableError as e:
             raise AssertionException("Error contacting UMAPI server: %s" % e)
 
+    def get_user_groups(self):
+        return list(self.iter_user_groups())
+
+    def iter_user_groups(self):
+        try:
+            for g in umapi_client.UserGroupsQuery(self.connection):
+                yield g
+        except umapi_client.UnavailableError as e:
+            raise AssertionException("Error contacting UMAPI server: %s" % e)
+
     def create_group(self,name):
         if name:
             ug = umapi_client.UserGroups(self.connection)

--- a/user_sync/connector/umapi.py
+++ b/user_sync/connector/umapi.py
@@ -160,6 +160,7 @@ class UmapiConnector(object):
         if name:
             ug = umapi_client.UserGroups(self.connection)
             ug.create(name, 'Automatically created by User Sync Tool')
+
     def get_action_manager(self):
         return self.action_manager
 

--- a/user_sync/connector/umapi.py
+++ b/user_sync/connector/umapi.py
@@ -151,7 +151,7 @@ class UmapiConnector(object):
 
     def iter_groups(self):
         try:
-            for g in umapi_client.UserGroupsQuery(self.connection):
+            for g in umapi_client.GroupsQuery(self.connection):
                 yield g
         except umapi_client.UnavailableError as e:
             raise AssertionException("Error contacting UMAPI server: %s" % e)

--- a/user_sync/rules.py
+++ b/user_sync/rules.py
@@ -390,14 +390,14 @@ class RuleProcessor(object):
                     self.logger.error('Target adobe group %s is not known; ignored', target_group_qualified_name)
 
             additional_groups = self.options.get('additional_groups', [])
-            for member_group in directory_user['member_groups']:
+            member_groups = directory_user.get('member_groups', [])
+            for member_group in member_groups:
                 for group_rule in additional_groups:
                     if group_rule['source'].match(member_group):
                         rename_group = group_rule['source'].sub(group_rule['target'], member_group)
                         umapi_info.add_mapped_group(rename_group)
                         for umapi_name, umapi_info in six.iteritems(self.umapi_info_by_name):
                             umapi_info.add_desired_group_for(user_key, rename_group)
-
 
         self.logger.debug('Total directory users after filtering: %d', len(filtered_directory_user_by_user_key))
         if self.logger.isEnabledFor(logging.DEBUG):

--- a/user_sync/rules.py
+++ b/user_sync/rules.py
@@ -72,7 +72,6 @@ class RuleProcessor(object):
         self.action_summary = {
             # these are in alphabetical order!  Always add new ones that way!
             'adobe_user_groups_created': 0,
-            'adobe_user_groups_deleted': 0,
             'directory_users_read': 0,
             'directory_users_selected': 0,
             'excluded_user_count': 0,
@@ -237,7 +236,6 @@ class RuleProcessor(object):
                 ['primary_users_created', 'Number of new Adobe users added'],
                 ['updated_user_count', 'Number of matching Adobe users updated'],
                 ['adobe_user_groups_created', 'Number of Adobe user-groups created'],
-                ['adobe_user_groups_deleted', 'Number of Adobe user-groups deleted'],
             ]
             if umapi_connectors.get_secondary_connectors():
                 action_summary_description += [

--- a/user_sync/rules.py
+++ b/user_sync/rules.py
@@ -395,6 +395,7 @@ class RuleProcessor(object):
                         for umapi_name, umapi_info in six.iteritems(self.umapi_info_by_name):
                             umapi_info.add_desired_group_for(user_key, rename_group)
 
+
         self.logger.debug('Total directory users after filtering: %d', len(filtered_directory_user_by_user_key))
         if self.logger.isEnabledFor(logging.DEBUG):
             self.logger.debug('Group work list: %s', dict([(umapi_name, umapi_info.get_desired_groups_by_user_key())

--- a/user_sync/rules.py
+++ b/user_sync/rules.py
@@ -176,7 +176,8 @@ class RuleProcessor(object):
         umapi_stats = JobStats('Push to UMAPI' if self.push_umapi else 'Sync with UMAPI', divider="-")
         umapi_stats.log_start(logger)
         if directory_connector is not None:
-            self.create_umapi_groups(umapi_connectors)
+            if self.options.get('process_groups'):
+                self.create_umapi_groups(umapi_connectors)
             self.sync_umapi_users(umapi_connectors)
         if self.will_process_strays:
             self.process_strays(umapi_connectors)

--- a/user_sync/rules.py
+++ b/user_sync/rules.py
@@ -480,7 +480,8 @@ class RuleProcessor(object):
             # pull all user groups from console
             on_adobe_groups = [normalize_string(g['groupName']) for g in umapi_connector.get_groups()]
             # verify if group exist and create
-            if self.options['auto_create']:
+            auto_create = self.options.get('auto_create', None)
+            if auto_create:
                 for mapped_group in mapped_groups:
                     if normalize_string(mapped_group) not in on_adobe_groups:
                         self.logger.info("Auto create user-group enabled: Creating %s" % mapped_group)

--- a/user_sync/rules.py
+++ b/user_sync/rules.py
@@ -472,10 +472,10 @@ class RuleProcessor(object):
         umapi_info, umapi_connector = self.get_umapi_info(PRIMARY_UMAPI_NAME), umapi_connectors.get_primary_connector()
         mapped_groups = umapi_info.get_non_normalize_mapped_groups()
         #pull all user groups from console
-        on_adobe_user_groups = [normalize_string(group['name']) for group in umapi_connector.get_groups()]
+        on_adobe_groups = [normalize_string(group['groupName']) for group in umapi_connector.get_groups()]
         #verify if group exist
         for mapped_group in mapped_groups:
-            if not normalize_string(mapped_group) in on_adobe_user_groups:
+            if not normalize_string(mapped_group) in on_adobe_groups:
                 self.logger.info("Auto create user-group enabled: Creating %s" % mapped_group)
                 try:
                     # create group

--- a/user_sync/rules.py
+++ b/user_sync/rules.py
@@ -391,8 +391,9 @@ class RuleProcessor(object):
                 else:
                     self.logger.error('Target adobe group %s is not known; ignored', target_group_qualified_name)
 
+            additional_groups = self.options.get('additional_groups', [])
             for member_group in directory_user['member_groups']:
-                for group_rule in self.options['directory_additional_groups']:
+                for group_rule in additional_groups:
                     if group_rule['source'].match(member_group):
                         rename_group = group_rule['source'].sub(group_rule['target'], member_group)
                         umapi_info.add_mapped_group(rename_group)

--- a/user_sync/rules.py
+++ b/user_sync/rules.py
@@ -385,6 +385,13 @@ class RuleProcessor(object):
                 else:
                     self.logger.error('Target adobe group %s is not known; ignored', target_group_qualified_name)
 
+            for member_group in directory_user['member_groups']:
+                for group_rule in self.options['directory_additional_groups']:
+                    if group_rule['source'].match(member_group):
+                        rename_group = group_rule['source'].sub(group_rule['target'], member_group)
+                        for umapi_name, umapi_info in six.iteritems(self.umapi_info_by_name):
+                            umapi_info.add_desired_group_for(user_key, rename_group)
+
         self.logger.debug('Total directory users after filtering: %d', len(filtered_directory_user_by_user_key))
         if self.logger.isEnabledFor(logging.DEBUG):
             self.logger.debug('Group work list: %s', dict([(umapi_name, umapi_info.get_desired_groups_by_user_key())


### PR DESCRIPTION
This feature adds mechanism for the sync tool to discover additional, non-mapped groups and add them to sync.  It also automatic group creation.

Configuration details can be found in `1 user-sync-config.yml`.  Additional information can be found in the "advanced configuration" manual page.

It introduces a new config option that specifies a set of one or more rules to identify and rename groups from this query to target for sync.  These groups are checked in the `memberOf` user attribute.  Rules to identify and rename these extra groups are defined in `user-sync-config.yml`.

```yaml
  additional_groups:
    - source: "ACL-(.+)"
      target: "ACL-Grp-(\1)"
    - source: "(.+)-ACL"
      target: "ACL-Grp-(\1)"
```

Groups can also optionally be auto-created.  If auto-create is enabled, then any Adobe group targeted through the additional group mechanism, group mapping or extension config will be created if the following conditions are met.

* Group is targeted for at least one user
* Group does not already exist

The auto-create boolean is defined in `user-sync-config.yml`.

```yaml
  group_sync_options:
    auto_create: False
```

Notes:

* Auto-deletion of groups is not supported at this time
* If all users are removed from an "additional group", the sync tool will not know that it needs to remove users from its corresponding Adobe group (the group must be targeted for at least one user)
* The proposed "additional groups" LDAP query was removed for performance reason and because it made the overall group query buggy

Fixes #339 