### PR TITLE
Update config.py for #336 and app.py for #337

### DIFF
--- a/user_sync/app.py
+++ b/user_sync/app.py
@@ -263,6 +263,9 @@ def log_parameters(argv, config_loader):
     :type config_loader: user_sync.config.ConfigLoader
     :return: None
     """
+    python_version = ' ' * 13 + 'Python %s.%s.%s' % sys.version_info[:3]
+    logger.info('')
+    logger.info(python_version)
     logger.info('------- Command line arguments -------')
     logger.info(' '.join(argv))
     logger.debug('-------- Resulting invocation options --------')

--- a/user_sync/app.py
+++ b/user_sync/app.py
@@ -263,9 +263,7 @@ def log_parameters(argv, config_loader):
     :type config_loader: user_sync.config.ConfigLoader
     :return: None
     """
-    python_version = ' ' * 13 + 'Python %s.%s.%s' % sys.version_info[:3]
-    logger.info('')
-    logger.info(python_version)
+    logger.info('Python version: %s.%s.%s on %s' % (sys.version_info[:3] + (sys.platform,)))
     logger.info('------- Command line arguments -------')
     logger.info(' '.join(argv))
     logger.debug('-------- Resulting invocation options --------')

--- a/user_sync/config.py
+++ b/user_sync/config.py
@@ -177,6 +177,7 @@ class ConfigLoader(object):
             raise AssertionException('You cannot specify both a --users arg and an --adobe-only-user-list arg')
         elif self.args['users']:
             # specifying --users overrides the configuration file default for this option
+            options['users'] = self.args['users']
             users_spec = self.args['users']
             stray_list_input_path = None
         elif self.args['adobe_only_user_list']:


### PR DESCRIPTION
Logs showed users option "all" even when "mapped" was provided via command-line