### PR TITLE
Logic correction to check for adobe_only_users (issue #375)

### DIFF
--- a/user_sync/config.py
+++ b/user_sync/config.py
@@ -196,12 +196,12 @@ class ConfigLoader(object):
             raise AssertionException('You cannot configure both a default "users" option (%s) '
                                      'and a default "adobe-only-user-list" option (%s)' %
                                      (' '.join(options['users']), options['adobe_only_user_list']))
-        elif options['users']:
-            users_spec = options['users']
-            stray_list_input_path = None
         elif options['adobe_only_user_list']:
             users_spec = None
             stray_list_input_path = options['adobe_only_user_list']
+        elif options['users']:
+            users_spec = options['users']
+            stray_list_input_path = None            
         else:
             raise AssertionException('You must specify either a "users" option or an "adobe-only-user-list" option.')
 

--- a/user_sync/config.py
+++ b/user_sync/config.py
@@ -173,8 +173,10 @@ class ConfigLoader(object):
 
         # --users and --adobe-only-user-list conflict with each other, so we need to disambiguate.
         # Argument specifications override configuration options, so you must have one or the other
-        # either as an argument or as a configured default.
-        if self.args['users'] and (self.args['adobe_only_user_list'] or options['adobe_only_user_list']):
+        # either as an argument or as a configured default.  For a complete check, we need to compare against
+        # BOTH the args values AND the options values (in order to catch the invocation defaults).
+        if (self.args['users'] or (options['users'] and options['users'] != self.invocation_defaults['users'])) \
+                and (self.args['adobe_only_user_list'] or options['adobe_only_user_list']):
             # specifying both --users and --adobe-only-user-list is an error
             raise AssertionException('You cannot specify both a --users arg and an --adobe-only-user-list arg')
         elif self.args['users']:
@@ -188,14 +190,6 @@ class ConfigLoader(object):
                 raise AssertionException('You cannot specify --adobe-only-user-list when using "push" strategy')
             users_spec = None
             stray_list_input_path = self.args['adobe_only_user_list']
-
-        # Check both that options['users'] exists, AND that it is not the default value before checking against
-        # the adobe_only_user_list parameter -  otherwise, defaults cause exception to be thrown unconditionally when
-        # the user list option is specified
-        elif (options['users'] and options['users'] != self.invocation_defaults['users']) and options['adobe_only_user_list']:
-            raise AssertionException('You cannot configure both a default "users" option (%s) '
-                                     'and a default "adobe-only-user-list" option (%s)' %
-                                     (' '.join(options['users']), options['adobe_only_user_list']))
         elif options['adobe_only_user_list']:
             users_spec = None
             stray_list_input_path = options['adobe_only_user_list']

--- a/user_sync/config.py
+++ b/user_sync/config.py
@@ -174,7 +174,7 @@ class ConfigLoader(object):
         # --users and --adobe-only-user-list conflict with each other, so we need to disambiguate.
         # Argument specifications override configuration options, so you must have one or the other
         # either as an argument or as a configured default.
-        if self.args['users'] and self.args['adobe_only_user_list']:
+        if self.args['users'] and (self.args['adobe_only_user_list'] or options['adobe_only_user_list']):
             # specifying both --users and --adobe-only-user-list is an error
             raise AssertionException('You cannot specify both a --users arg and an --adobe-only-user-list arg')
         elif self.args['users']:


### PR DESCRIPTION
In response to #375 

When reading from user-sync-config.yml, the adobe_only_users key was superceeded by options['users'].  Swapped comparison to take the adobe_only_users key instead if present.  

Refactored and updated logical comparison to account for both invocation defaults AND command line options when checking for the users + adobe_only_user_list parameters so that any combination of the two is disallowed.  Previously, it was possible to specify --users on the command line even if the adobe_only_user_list was specified in the configuration file (it was ignored then).  Now, the appropriate exception is thrown.