### PR TITLE
Fix for issue #381 / Unparsed config args

### DIFF
--- a/user_sync/config.py
+++ b/user_sync/config.py
@@ -105,7 +105,7 @@ class ConfigLoader(object):
                 elif isinstance(v, list):
                     val = invocation_config.get_list(k, True)
                     if val:
-                        options[k] = val
+                        options[k] = self.parse_args(val[0])
                 else:
                     val = invocation_config.get_string(k, True)
                     if val:
@@ -530,6 +530,9 @@ class ConfigLoader(object):
         directory_connectors_config = self.get_directory_connector_configs()
         self.main_config.report_unused_values(self.logger, [directory_connectors_config])
 
+    def parse_args(self, argString):
+        char = argString[-1:]
+        return argString.rstrip(char).split(char) if (char == "'" or char == '"') else argString.split(" ")
 
 class ObjectConfig(object):
     def __init__(self, scope):


### PR DESCRIPTION

https://github.com/adobe-apiplatform/user-sync.py/issues/381

Invocation Defaults for user-sync-config now parsed if they are list type correctly.  Added small parser for ID to do this.  It parses the key values such that they match the corresponding command line values.

For example, specifying groups in the invocation defaults now yields an input list of:
['group', 'GroupA,GroupB']

Previously, it was parsed as a single value like this:
['group "GroupA,GroupB"]

Which could not be intepreted as a valid argument.

This fix resolves other list inputs as well:
eg, adobe-only-user-action write-file xyz.csv now works too from invocation defaults.

