### PR TITLE
Fix/product admin role

### DIFF
--- a/docs/en/user-manual/configuring_user_sync_tool.md
+++ b/docs/en/user-manual/configuring_user_sync_tool.md
@@ -272,6 +272,57 @@ groups:
       - Accounting_Department
 ```
 
+### Mapping Admin Roles
+
+Admin roles can be assigned to users by the User Sync tool using
+special group names and prefixes.  Using these special naming
+conventions, admin roles can be assigned like any normal product
+profile or user group.
+
+| Admin Role | Name or Prefix |
+|:---|:---|
+| System Admin* | `_org_admin` |
+| Support Admin | `_support_admin` |
+| Deployment Admin | `_deployment_admin` |
+| User Group or Profile Admin | `_admin_[GROUP_NAME]` |
+| Product Admin | `_product_admin_[PRODUCT_NAME]` |
+
+{: .bordertablestyle }
+
+*System admin roles can't currently be assigned by the UMAPI, so they
+are not supported in the User Sync Tool
+
+**Notes about the Product Admin role:**
+
+* It may be necessary to manually assign a user as admin to a product
+before syncing users as product admins.
+* The product admin role group name is case-sensitive.
+* It is often necessary to assign users to at least one profile on the
+same product as the admin role.
+
+See the [UMAPI Docs](https://adobe-apiplatform.github.io/umapi-documentation/en/api/ActionsCmds.html#addRemoveAttr) for more details.
+
+#### Role Assignment Example
+
+```YAML
+groups:
+  - directory_group: Acrobat Admins
+    adobe_groups:
+      # assuming the product name is "Adobe Acrobat Pro DC"
+      - Default Acrobat Pro DC configuration
+      - _product_admin_Adobe Acrobat Pro DC
+  - directory_group: Support and Deployment Admins
+    adobe_groups:
+      - _support_admin
+      - _deployment_admin
+  - directory_group: Department A Admins
+    adobe_groups:
+      # assuming a user group called "Department A"
+      - Department A
+      - _admin_Department A
+```
+
+
 ### Configure limits
 
 User accounts are removed from the Adobe system when

--- a/docs/en/user-manual/configuring_user_sync_tool.md
+++ b/docs/en/user-manual/configuring_user_sync_tool.md
@@ -286,7 +286,6 @@ profile or user group.
 | Deployment Admin | `_deployment_admin` |
 | User Group or Profile Admin | `_admin_[GROUP_NAME]` |
 | Product Admin | `_product_admin_[PRODUCT_NAME]` |
-
 {: .bordertablestyle }
 
 *System admin roles can't currently be assigned by the UMAPI, so they

--- a/user_sync/helper.py
+++ b/user_sync/helper.py
@@ -41,6 +41,15 @@ def normalize_string(string_value):
     return string_value.strip().lower() if string_value is not None else None
 
 
+def normal_group(group):
+    """
+    Returns true if group name can be normalized, false otherwise
+    :param group: str
+    :return: bool
+    """
+    return False if group.starts_with('_product_admin_') else True
+
+
 class CSVAdapter:
     """
     Read and write CSV files to and from lists of dictionaries

--- a/user_sync/helper.py
+++ b/user_sync/helper.py
@@ -47,7 +47,7 @@ def normal_group(group):
     :param group: str
     :return: bool
     """
-    return False if group.starts_with('_product_admin_') else True
+    return False if group.startswith('_product_admin_') else True
 
 
 class CSVAdapter:

--- a/user_sync/rules.py
+++ b/user_sync/rules.py
@@ -833,7 +833,7 @@ class RuleProcessor(object):
         result = set()
         if group_names is not None:
             for group_name in group_names:
-                normalized_group_name = normalize_string(group_name) if normal_group(group_name) else group_name
+                normalized_group_name = normalize_string(group_name) if normal_group(group_name) else group_name.strip()
                 result.add(normalized_group_name)
         return result
 
@@ -1161,7 +1161,7 @@ class UmapiTargetInfo(object):
         """
         :type group: str
         """
-        normalized_group_name = normalize_string(group) if normal_group(group) else group
+        normalized_group_name = normalize_string(group) if normal_group(group) else group.strip()
         self.mapped_groups.add(normalized_group_name)
 
     def get_mapped_groups(self):
@@ -1186,7 +1186,7 @@ class UmapiTargetInfo(object):
         if desired_groups is None:
             self.desired_groups_by_user_key[user_key] = desired_groups = set()
         if group is not None:
-            normalized_group_name = normalize_string(group) if normal_group(group) else group
+            normalized_group_name = normalize_string(group) if normal_group(group) else group.strip()
             desired_groups.add(normalized_group_name)
 
     def add_umapi_user(self, user_key, user):

--- a/user_sync/rules.py
+++ b/user_sync/rules.py
@@ -25,7 +25,7 @@ import six
 import user_sync.connector.umapi
 import user_sync.error
 import user_sync.identity_type
-from user_sync.helper import normalize_string, CSVAdapter, JobStats
+from user_sync.helper import normalize_string, normal_group, CSVAdapter, JobStats
 
 GROUP_NAME_DELIMITER = '::'
 PRIMARY_UMAPI_NAME = None
@@ -833,8 +833,7 @@ class RuleProcessor(object):
         result = set()
         if group_names is not None:
             for group_name in group_names:
-                normalized_group_name = normalize_string(group_name) if not group_name.startswith('_product_admin_')\
-                    else group_name
+                normalized_group_name = normalize_string(group_name) if normal_group(group_name) else group_name
                 result.add(normalized_group_name)
         return result
 
@@ -1162,7 +1161,7 @@ class UmapiTargetInfo(object):
         """
         :type group: str
         """
-        normalized_group_name = normalize_string(group) if not group.startswith('_product_admin_') else group
+        normalized_group_name = normalize_string(group) if normal_group(group) else group
         self.mapped_groups.add(normalized_group_name)
 
     def get_mapped_groups(self):
@@ -1187,7 +1186,7 @@ class UmapiTargetInfo(object):
         if desired_groups is None:
             self.desired_groups_by_user_key[user_key] = desired_groups = set()
         if group is not None:
-            normalized_group_name = normalize_string(group) if not group.startswith('_product_admin_') else group
+            normalized_group_name = normalize_string(group) if normal_group(group) else group
             desired_groups.add(normalized_group_name)
 
     def add_umapi_user(self, user_key, user):

--- a/user_sync/rules.py
+++ b/user_sync/rules.py
@@ -833,7 +833,8 @@ class RuleProcessor(object):
         result = set()
         if group_names is not None:
             for group_name in group_names:
-                normalized_group_name = normalize_string(group_name)
+                normalized_group_name = normalize_string(group_name) if not group_name.startswith('_product_admin_')\
+                    else group_name
                 result.add(normalized_group_name)
         return result
 
@@ -1161,7 +1162,7 @@ class UmapiTargetInfo(object):
         """
         :type group: str
         """
-        normalized_group_name = normalize_string(group)
+        normalized_group_name = normalize_string(group) if not group.startswith('_product_admin_') else group
         self.mapped_groups.add(normalized_group_name)
 
     def get_mapped_groups(self):
@@ -1186,7 +1187,7 @@ class UmapiTargetInfo(object):
         if desired_groups is None:
             self.desired_groups_by_user_key[user_key] = desired_groups = set()
         if group is not None:
-            normalized_group_name = normalize_string(group)
+            normalized_group_name = normalize_string(group) if not group.startswith('_product_admin_') else group
             desired_groups.add(normalized_group_name)
 
     def add_umapi_user(self, user_key, user):


### PR DESCRIPTION
At this time, product admin role group names are treated as case-sensitive by the UMAPI.  The User Sync Tool cannot currently assign product admin roles because it converts all group names to lowercase when assigning users to groups.  There is an urgent need for Stock customers to assign Adobe Stock admins with the User Sync Tool.  Product admin access is needed for users that require access to Stock licensing history reports in the Stock console.

This issue should be getting resolved on the UMAPI side, but in the meantime we need to make an exception for product admin role names and assign them to users with their original letter casing.

If this issue does get fixed in the UMAPI, we can remove the exception.

This PR targets master because we need this released in 2.3.1.  v2 currently has updates related to 2.4 that we don't want to release at this time.  Once this PR is merged, I'll rebase v2 against master.

I've tested this update with user creation, group updates, as well as user deprovisioning, removal and deletion.  I've also tested those workflows in a multi-org setup (which is common with Stock customers because they tend to have separate Stock-only admin consoles).

Also included in the PR are some needed documentation updates that cover admin role assignment in general.

Fixes #393 