### PR TITLE
Add documentation on connecting to Azure AD

### DIFF
--- a/docs/en/success-guide/setup_config_files.md
+++ b/docs/en/success-guide/setup_config_files.md
@@ -42,6 +42,17 @@ If you are driving User Sync from a file, you can skip setting up connector-ldap
 
 If you need a non-default LDAP query to select the desired set of users, it is setup in this file as part of the all\_users\_filter config parameter.
 
+#### Connecting to Microsoft Azure AD
+Microsoft Azure AD is relatively straightforward to setup.  However, some prerequisite work must be done to enable LDAPS on the Azure tennant.  You will need to add Azure Domain Services, and setup password-hash synchronization before the tool will be able to bind to the domain.  
+The following Microsoft guides can walk you through the process for getting LDAPS enabled:
+
+- [Setup Azure Domain Services](https://docs.microsoft.com/en-us/azure/active-directory-domain-services/active-directory-ds-getting-started)<br/>
+- [Configure LDAPS on Azure AD](https://docs.microsoft.com/en-us/azure/active-directory-domain-services/active-directory-ds-admin-guide-configure-secure-ldap)
+
+Once that is done, you will be able to connect to the Azure AD using normal LDAP credentials with the UST.  Please note, there is **no** requirement for using TLS or an SSL cert on the UST side - you should be able to connect by binding to port 636 with your Azure AD service account. In other words, the following key in connector-ldap.yml can be set to False (the default)
+
+- require_tls_cert: False
+
 
 ### Adobe UMAPI Credentials 
 


### PR DESCRIPTION
Added a brief overview on how to connect UST to Azure AD, to clarify that this can be done provided certain Azure prerequisites are in place.  Note: SSL Cert / TLS are NOT required in the connector-ldap.yml, but port 636 and ldaps are required to connect.

Once this is added, I can link to it on the config doc (not the success guide)