### PR TITLE
Avoid App Termination when UMAPI Create Action error

### DIFF
--- a/user_sync/connector/umapi.py
+++ b/user_sync/connector/umapi.py
@@ -183,7 +183,7 @@ class UmapiConnector(object):
         if len(commands) > 0:
             action_manager = self.get_action_manager()
             action = action_manager.create_action(commands)
-            if action:
+            if action is not None:
                 action_manager.add_action(action, callback)
 
 
@@ -320,7 +320,7 @@ class ActionManager(object):
                                              requestID=self.get_next_request_id())
         except ValueError as e:
             self.logger.error("Skipping user - Error creating umapi Action: %s" % e)
-            return
+            return None
         for command in commands.do_list:
             command_name, command_param = command
             command_function = getattr(action, command_name)

--- a/user_sync/connector/umapi.py
+++ b/user_sync/connector/umapi.py
@@ -183,7 +183,8 @@ class UmapiConnector(object):
         if len(commands) > 0:
             action_manager = self.get_action_manager()
             action = action_manager.create_action(commands)
-            action_manager.add_action(action, callback)
+            if action:
+                action_manager.add_action(action, callback)
 
 
 class Commands(object):
@@ -318,7 +319,8 @@ class ActionManager(object):
             action = umapi_client.UserAction(umapi_identity_type, email, username, domain,
                                              requestID=self.get_next_request_id())
         except ValueError as e:
-            raise AssertionException("Error creating umapi Action: %s" % e)
+            self.logger.error("Skipping user - Error creating umapi Action: %s" % e)
+            return
         for command in commands.do_list:
             command_name, command_param = command
             command_function = getattr(action, command_name)


### PR DESCRIPTION
This will skip over the problematic users instead terminate the entire sync process.

Before:

> 2018-10-31 10:04:07 78637 CRITICAL main - Error creating umapi Action: 'Hschowãlter@adobeccetest.com': Illegal email format (must be ascii, unquoted, with no comment part)

After:

> 2018-10-31 10:06:20 78692 ERROR umapi.action - Skipping user - Error creating umapi Action: 'Hschowãlter@adobeccetest.com': Illegal email format (must be ascii, unquoted, with no comment part)


#422 