### PR TITLE
Log a meaningful error if Okta connector isn't invoked correctly #416 - V2 for release 2.4   

### DIFF
--- a/user_sync/app.py
+++ b/user_sync/app.py
@@ -90,7 +90,6 @@ def main(args=sys.argv[1:]):
 
     except AssertionException as e:
         if not e.is_reported():
-            logger.critical("Check settings on user-sync-config.yml file, as UST could not retrieve values using default ldap settings")
             logger.critical("%s", e)
             e.set_reported()
     except KeyboardInterrupt:

--- a/user_sync/app.py
+++ b/user_sync/app.py
@@ -90,7 +90,7 @@ def main(args=sys.argv[1:]):
 
     except AssertionException as e:
         if not e.is_reported():
-            logger.critical("Check settings on user-sync-config.yml file or on the command line, as UST could not retrieve values using default ldap settings")
+            logger.critical("Check settings on user-sync-config.yml file, as UST could not retrieve values using default ldap settings")
             logger.critical("%s", e)
             e.set_reported()
     except KeyboardInterrupt:

--- a/user_sync/app.py
+++ b/user_sync/app.py
@@ -90,6 +90,7 @@ def main(args=sys.argv[1:]):
 
     except AssertionException as e:
         if not e.is_reported():
+            logger.critical("Check settings on user-sync-config.yml file or on the command line, as UST could not retrieve values using default ldap settings")
             logger.critical("%s", e)
             e.set_reported()
     except KeyboardInterrupt:

--- a/user_sync/config.py
+++ b/user_sync/config.py
@@ -323,6 +323,12 @@ class ConfigLoader(object):
         """
         options = {}
         connectors_config = self.get_directory_connector_configs()
+
+        if connectors_config is not None:
+            for accessed_keys_type in connectors_config.accessed_keys:
+                if (accessed_keys_type =='okta') and (connector_name == 'ldap'):
+                    raise AssertionException("Failed to match request : for Okta Connector type receiving LDAP as input type from commnand line")
+
         if connectors_config is not None:
             connector_item = connectors_config.get_list(connector_name, True)
             options = self.get_dict_from_sources(connector_item)


### PR DESCRIPTION


- removed line from app.py default AssertionException block 
-  added separate code block on config.py file to validate this condition under get_directory_connector_options definition.