### PR TITLE
Add ability to skip users based on criteria from extension config

### DIFF
--- a/examples/config files - custom attributes and mappings/extension-config.yml
+++ b/examples/config files - custom attributes and mappings/extension-config.yml
@@ -49,6 +49,8 @@ extended_adobe_groups:
 #                         # out: Adobe-side dashboard groups as potentially changed by hook code
 #     hook_storage        # for exclusive use by hook code: initialized to None; persists across per-user calls
 #     logger              # an object of type logging.logger which outputs to the console and/or file log
+#     skip_user           # True or False - if true, user will not be synchronized
+#                         # This can be useful for specifying criteria (e.g., filtering by attribute)
 #
 after_mapping_hook: |
   bc = source_attributes.get('bc')

--- a/user_sync/rules.py
+++ b/user_sync/rules.py
@@ -405,12 +405,10 @@ class RuleProcessor(object):
                 self.log_after_mapping_hook_scope(after_call=True)
 
                 # skip user if hook specifies true
-                skip_user = self.after_mapping_hook_scope['skip_user']
-                if type(skip_user) is bool and skip_user:
-                    self.get_umapi_info(PRIMARY_UMAPI_NAME).get_desired_groups_by_user_key().pop(user_key)
+                if self.after_mapping_hook_scope['skip_user'] is True:
                     self.directory_user_by_user_key.pop(user_key)
-                    if user_key in filtered_directory_user_by_user_key:
-                        self.filtered_directory_user_by_user_key.pop(user_key)
+                    self.filtered_directory_user_by_user_key.pop(user_key)
+                    self.get_umapi_info(PRIMARY_UMAPI_NAME).get_desired_groups_by_user_key().pop(user_key)
                     continue
 
                 # copy modified attributes back to the user object


### PR DESCRIPTION
Feature code for #495

https://github.com/adobe-apiplatform/user-sync.py/issues/465

Simple addition that permits skipping of users from extension config.

Resulting behavior:
When applied to a user, they are effectively removed from the sync process.  This has the same end effect as removing them from the AD group or all users filter, except that the decision to remove them has not been made until after the comparison (owing to where the extension config hooks in).

  - if they exist on the admin console side and are skipped they will be treated like adobe-only-users.  If in a target group, they will be removed from that group.  
  - using --adobe-only-user-action flag seems to have the normal effect as for other users.  Skipping a user causes them to be affected by this flag.
  - if they do not exist on the admin console and are skipped, they will not be created /  provisioned
  - In push sync mode, users will only be created if they are NOT skipped

Example extension config code adds all users in AD OU "Specific OU" to the console group "AdobeGroupForOUUsers" and skips any user not in that OU:

```python
extended_attributes:
  - distinguishedName
extended_adobe_groups:
  - AdobeGroupForOUUsers

after_mapping_hook: | 
if "Specific OU" in source_attributes.get('distinguishedName'):
  target_groups.add('AdobeGroupForOUUsers')`
else:
  skip_user = True
```