### PR TITLE
Exclude Users - Ignore Case

### DIFF
--- a/user_sync/config.py
+++ b/user_sync/config.py
@@ -495,7 +495,7 @@ class ConfigLoader(object):
                 try:
                     # add "match begin" and "match end" markers to ensure complete match
                     # and compile the patterns because we will use them over and over
-                    exclude_users.append(re.compile(r'\A' + regexp + r'\Z', re.UNICODE))
+                    exclude_users.append(re.compile(r'\A' + regexp + r'\Z', re.UNICODE | re.IGNORECASE))
                 except re.error as e:
                     validation_message = ('Illegal regular expression (%s) in %s: %s' %
                                           (regexp, 'exclude_identity_types', e))


### PR DESCRIPTION
fixes #468 

I've not tested it, but it should work. I don't think it's practical to have users use the python regex inline modes/modifiers and can't think of a situation where case sensitivity would be required - the only caveat is that I don't believe you can turn case sensitivity back on inline with python. 