### PR TITLE
Fix for #450

### DIFF
--- a/user_sync/connector/directory_ldap.py
+++ b/user_sync/connector/directory_ldap.py
@@ -214,7 +214,7 @@ class LDAPDirectoryConnector(object):
             ungrouped_users = 0
             grouped_users = 0
             try:
-                for user_dn, user in self.iter_users(all_users_filter, extended_attributes):
+                for user_dn, user in self.iter_users(base_dn, all_users_filter, extended_attributes):
                     if not user['groups']:
                         ungrouped_users += 1
                     else:


### PR DESCRIPTION
iter_users had its signature updated to accept 3 arguments in v2.4 (ea91cb05d9aacbfd874d1be7ad6c63c9d328f9b0).  

This bug was fixed for one of  the other method calls immediately after the commit (b71efa60621a560261808f149247d2178ada7e42),  but this method call was not updated accordingly, causing this behavior.