### PR TITLE
#463 fix additional groups bug

### DIFF
--- a/examples/config files - basic/user-sync-config.yml
+++ b/examples/config files - basic/user-sync-config.yml
@@ -204,9 +204,9 @@ directory_users:
   # see https://docs.python.org/howto/regex.html )
   # additional_groups:
   #   - source: "ACL-(.+)"
-  #     target: "ACL-Grp-(\1)"
+  #     target: "ACL-Grp-(\\1)"
   #   - source: "(.+)-ACL"
-  #     target: "ACL-Grp-(\1)"
+  #     target: "ACL-Grp-(\\1)"
 
   # (optional) group_sync_options (default: all options false)
   # Options that govern the automatic creation and/or deletion of Adobe user groups

--- a/user_sync/connector/directory_ldap.py
+++ b/user_sync/connector/directory_ldap.py
@@ -396,7 +396,7 @@ class LDAPDirectoryConnector(object):
 
         if not groups:
             return group_names
-        elif type(groups) is str:
+        elif isinstance(groups, str):
             groups = [groups]
 
         for group_dn in map(dn.str2dn, groups):

--- a/user_sync/connector/directory_ldap.py
+++ b/user_sync/connector/directory_ldap.py
@@ -393,6 +393,12 @@ class LDAPDirectoryConnector(object):
         """
         group_names = []
         groups = LDAPValueFormatter.get_attribute_value(user, 'memberOf')
+
+        if not groups:
+            return group_names
+        elif type(groups) is str:
+            groups = [groups]
+
         for group_dn in map(dn.str2dn, groups):
             group_cn = self.get_cn_from_dn(group_dn)
             if group_cn:


### PR DESCRIPTION
directory_ldap:
- Account for the case when a user has only 1 group.  LDAPFormatter returns a string instead of a list because first_only is set to true.  We cannot set this to false, because the other attributes depend on it.   We also cannot modify the dn method as it is not part of User Sync.  So, the best solution is to create a one item list in this case.

- If a user has no groups (--users all), LDAPFormatter returns None for the group list -- in this case, we need to immediately return instead of trying to call map() on the NoneType object.

examples\user-sync-config.yml:
- Update the regular expression to escape the "\\" character.  Tested working this way.  Also verified that configapp is able to maintain these fields.  After processing by the app, the following transformation takes place:
```
     source: "ACL-(.+)"               ->          source: ACL-(.+)
     target: "ACL-Grp-(\\1)"          ->          target: ACL-Grp-(\1)
```
And the mapping works in both cases.
