### PR TITLE
Feature - CLI Refactor

### DIFF
--- a/.build/pre_build.py
+++ b/.build/pre_build.py
@@ -1,3 +1,23 @@
+import os
+import shutil
+
+
+def cd():
+    os.chdir(os.path.realpath(os.path.join(os.path.dirname(__file__), '..')))
+
+
+def bundle_example_config():
+    examples_dir = os.path.join('examples', 'config files - basic')
+    files = [os.path.join(examples_dir, f) for f in os.listdir(examples_dir) if
+             os.path.isfile(os.path.join(examples_dir, f))]
+    bundle_dir = os.path.join('user_sync', 'resources', 'examples')
+    if not os.path.exists(bundle_dir):
+        os.mkdir(bundle_dir)
+    for f in files:
+        dest = os.path.join(bundle_dir, os.path.split(f)[-1])
+        shutil.copy(f, dest)
+
+
 if __name__ == '__main__':
     cd()
     bundle_example_config()

--- a/.build/pre_build.py
+++ b/.build/pre_build.py
@@ -1,2 +1,3 @@
 if __name__ == '__main__':
-    pass
+    cd()
+    bundle_example_config()

--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,8 @@ ENV/
 _site
 .sass-cache
 .jekyll-metadata
+
+user_sync/resources/*
+!user_sync/resources/__init__.py
+!user_sync/resources/README.md
+!user_sync/resources/manual_url

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ endif
 pex:
 	python -m pip install --upgrade pip
 	python -m pip install --upgrade 'wheel<0.30.0' requests pex==1.5.3
+	python .build/pre_build.py
 	-$(RM) $(output_dir)
 	pex -v -o $(output_dir)/$(output_filename)$(output_file_extension) -m user_sync.app \
 		-f $(prebuilt_dir) \

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(name='user-sync',
           'PyYAML',
           'six',
           'umapi-client>=2.12',
+          'click',
       ],
       extras_require={
           ':sys_platform=="linux" or sys_platform=="linux2"': [

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from setuptools import setup
+from setuptools import setup, find_packages
 
 version_namespace = {}
 with open('user_sync/version.py') as f:
@@ -44,7 +44,7 @@ setup(name='user-sync',
       maintainer='Daniel Brotsky',
       maintainer_email='dbrotsky@adobe.com',
       license='MIT',
-      packages=['user_sync', 'user_sync.connector'],
+      packages=find_packages(),
       install_requires=[
           'keyring',
           'okta==0.0.3.1',
@@ -55,6 +55,7 @@ setup(name='user-sync',
           'six',
           'umapi-client>=2.12',
           'click',
+          'click-default-group',
       ],
       extras_require={
           ':sys_platform=="linux" or sys_platform=="linux2"': [
@@ -74,4 +75,5 @@ setup(name='user-sync',
               'user_sync = user_sync.app:main'
           ]
       },
+      package_data={'user_sync.resources': ['*', 'examples/*']},
       zip_safe=False)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import os
 import pytest
+from user_sync import config
 
 
 @pytest.fixture
@@ -7,3 +8,20 @@ def fixture_dir():
     return os.path.abspath(
            os.path.join(
              os.path.dirname(__file__), 'fixture'))
+
+
+@pytest.fixture
+def cli_args():
+    def _cli_args(args_in):
+        """
+        :param dict args:
+        :return dict:
+        """
+
+        args_out = {}
+        for k in config.ConfigLoader.invocation_defaults:
+            args_out[k] = None
+        for k, v in args_in.items():
+            args_out[k] = v
+        return args_out
+    return _cli_args

--- a/user_sync/app.py
+++ b/user_sync/app.py
@@ -22,6 +22,7 @@ import argparse
 import logging
 import os
 import sys
+import click
 from datetime import datetime
 
 import six
@@ -32,6 +33,7 @@ import user_sync.connector.umapi
 import user_sync.helper
 import user_sync.lockfile
 import user_sync.rules
+import user_sync.cli
 from user_sync.error import AssertionException
 from user_sync.version import __version__ as app_version
 
@@ -55,27 +57,116 @@ def init_console_log():
 console_log_handler = init_console_log()
 
 
-def main(args=sys.argv[1:]):
-    """Top level entry point.
+@click.command()
+@click.help_option('-h', '--help')
+@click.version_option(None, '-v', '--version', message='%(prog)s %(version)s')
+@click.option('--config-file-encoding', 'encoding_name',
+              help="encoding of your configuration files",
+              default=user_sync.config.ConfigLoader.config_defaults['config_encoding'],
+              show_default=True,
+              type=str,
+              nargs=1,
+              metavar='encoding-name')
+@click.option('-c', '--config-filename',
+              help="path to your main configuration file",
+              default=user_sync.config.ConfigLoader.config_defaults['config_filename'],
+              show_default=True,
+              type=str,
+              nargs=1,
+              metavar='path-to-file')
+@click.option('--adobe-only-user-action',
+              help="specify what action to take on Adobe users that don't match users from the "
+                   "directory.  Options are 'exclude' (from all changes), "
+                   "'preserve' (as is except for --process-groups, the default), "
+                   "'write-file f' (preserve and list them), "
+                   "'remove-adobe-groups' (but do not remove users)"
+                   "'remove' (users but preserve cloud storage), "
+                   "'delete' (users and their cloud storage), ",
+              cls=user_sync.cli.OptionMulti,
+              type=list,
+              show_default=True,
+              default=['preserve'],
+              metavar='exclude|preserve|delete|remove|remove-adobe-groups|write-file [path-to-file.csv]')
+@click.option('--adobe-only-user-list',
+              help="instead of computing Adobe-only users (Adobe users with no matching users "
+                   "in the directory) by comparing Adobe users with directory users, "
+                   "the list is read from a file (see --adobe-only-user-action write-file). "
+                   "When using this option, you must also specify what you want done with Adobe-only "
+                   "users by also including --adobe-only-user-action and one of its arguments",
+              type=str,
+              nargs=1,
+              metavar='input_path')
+@click.option('--adobe-users',
+              help="specify the adobe users to pull from UMAPI. Legal values are 'all' (the default), "
+                   "'group names' (one or more specified groups), 'mapped' (all groups listed in "
+                   "the configuration file)",
+              cls=user_sync.cli.OptionMulti,
+              type=list,
+              show_default=True,
+              default=['all'],
+              metavar='all|mapped|group [group list]')
+@click.option('--connector',
+              help='specify a connector to use; default is LDAP (or CSV if --users file is specified)',
+              cls=user_sync.cli.OptionMulti,
+              type=list,
+              show_default=True,
+              default=['ldap'],
+              metavar='ldap|okta|csv [path-to-file.csv]')
+@click.option('--process-groups/--no-process-groups',
+              help='if membership in mapped groups differs between the enterprise directory and Adobe sides, '
+                   'the group membership is updated on the Adobe side so that the memberships in mapped '
+                   'groups match those on the enterprise directory side.',
+              default=False)
+@click.option('--strategy',
+              help="whether to fetch and sync the Adobe directory against the customer directory "
+                   "or just to push each customer user to the Adobe side.  Default is to fetch and sync.",
+              nargs=1,
+              type=str,
+              metavar='sync|push',
+              default='sync',
+              show_default=True)
+@click.option('-t/-T', '--test-mode/--no-test-mode',
+              help='enable test mode (API calls do not execute changes on the Adobe side).',
+              default=False)
+@click.option('--user-filter',
+              help='limit the selected set of users that may be examined for syncing, with the pattern '
+                   'being a regular expression.',
+              nargs=1,
+              type=str,
+              metavar='pattern')
+@click.option('--users',
+              help="specify the users to be considered for sync. Legal values are 'all' (the default), "
+                   "'group names' (one or more specified groups), 'mapped' (all groups listed in "
+                   "the configuration file), 'file f' (a specified input file).",
+              cls=user_sync.cli.OptionMulti,
+              type=list,
+              show_default=True,
+              default=['all'],
+              metavar='all|file|mapped|group [group list or path-to-file.csv]')
+@click.option('--update-user-info/--no-update-user-info',
+              help='user attributes on the Adobe side are updated from the directory.',
+              default=False)
+def main(**kwargs):
+    """User Sync from Adobe
 
-    To invoke User Sync from your code in an embedded fashion,
-    call this function, specifying the desired arguments.
+    Full documentation:
+
+    https://adobe-apiplatform.github.io/user-sync.py/en/user-manual/
+
+    NOTE: The defaults documented here can be overridden in `invocation_defaults` in
+    `user-sync-config.yml`.  However, any options explicitly set on the command line will
+    override any options set in `invocation_defaults`.
     """
     run_stats = None
     try:
-        try:
-            arg_obj = process_args(args)
-        except SystemExit:
-            return
-
         # load the config files and start the file logger
-        config_loader = user_sync.config.ConfigLoader(arg_obj)
+        config_loader = user_sync.config.ConfigLoader(kwargs)
         init_log(config_loader.get_logging_config())
 
         # add start divider, app version number, and invocation parameters to log
         run_stats = user_sync.helper.JobStats('Run (User Sync version: ' + app_version + ')', divider='=')
         run_stats.log_start(logger)
-        log_parameters(args, config_loader)
+        log_parameters(sys.argv[1:], config_loader)
 
         script_dir = os.path.dirname(os.path.realpath(sys.argv[0]))
         lock_path = os.path.join(script_dir, 'lockfile')
@@ -108,112 +199,13 @@ def main(args=sys.argv[1:]):
             run_stats.log_end(logger)
 
 
-def process_args(args=None):
+def process_args():
     """Define and parse the command-line (or passed) args.
 
     All of the arg defaults are actually held in the config module or config files,
     and the command line is just used to override those, so we don't define defaults here.
     """
-    # first define the standard args implemented by argparse ('-v', -h')
-    parser = argparse.ArgumentParser(description='User Sync from Adobe')
-    parser.add_argument('-v', '--version', action='version', version='%(prog)s ' + app_version)
-
-    # next define the arguments that affect reading the configuration file
-    # these are listed in alphabetical order!  always add new ones that way!
-    parser.add_argument('--config-file-encoding',
-                        help="encoding of your configuration files (default %s)".format(
-                            user_sync.config.ConfigLoader.config_defaults['config_encoding']
-                        ),
-                        metavar='encoding-name',
-                        dest='encoding_name')
-    parser.add_argument('-c', '--config-filename',
-                        help="path to your main configuration file (default %s)".format(
-                            user_sync.config.ConfigLoader.config_defaults['config_filename']
-                        ),
-                        metavar='path-to-file',
-                        dest='config_filename')
-
-    # finally define the arguments that affect processing operations;
-    # these are listed in alphabetical order!  always add new ones that way!
-    parser.add_argument('--adobe-only-user-action',
-                        help="specify what action to take on Adobe users that don't match users from the "
-                             "directory.  Options are 'exclude' (from all changes), "
-                             "'preserve' (as is except for --process-groups, the default), "
-                             "'write-file f' (preserve and list them), "
-                             "'remove-adobe-groups' (but do not remove users)"
-                             "'remove' (users but preserve cloud storage), "
-                             "'delete' (users and their cloud storage), ",
-                        nargs="+",
-                        metavar=('exclude|preserve|delete|remove|remove-adobe-groups|write-file', 'path-to-file.csv'),
-                        dest='adobe_only_user_action')
-    parser.add_argument('--adobe-only-user-list',
-                        help="instead of computing Adobe-only users (Adobe users with no matching users "
-                             "in the directory) by comparing Adobe users with directory users, "
-                             "the list is read from a file (see --adobe-only-user-action write-file). "
-                             "When using this option, you must also specify what you want done with Adobe-only "
-                             "users by also including --adobe-only-user-action and one of its arguments",
-                        metavar='input_path',
-                        dest='adobe_only_user_list')
-    parser.add_argument('--adobe-users',
-                        help="specify the adobe users to pull from UMAPI. Legal values are 'all' (the default), "
-                             "'group names' (one or more specified groups), 'mapped' (all groups listed in "
-                             "the configuration file)",
-                        nargs="+",
-                        metavar='all|mapped|group',
-                        dest='adobe_users')
-    parser.add_argument('--connector',
-                        help='specify a connector to use; default is LDAP (or CSV if --users file is specified)',
-                        nargs='+',
-                        metavar=('ldap|okta|csv', 'path-to-file.csv'),
-                        dest='connector')
-    parser.add_argument('--process-groups',
-                        help='if membership in mapped groups differs between the enterprise directory and Adobe sides, '
-                             'the group membership is updated on the Adobe side so that the memberships in mapped '
-                             'groups match those on the enterprise directory side.',
-                        action='store_true',
-                        dest='process_groups')
-    parser.add_argument('--no-process-groups',
-                        help='if membership in mapped groups differs between the enterprise directory and Adobe sides, '
-                             'the group membership is updated on the Adobe side so that the memberships in mapped '
-                             'groups match those on the enterprise directory side.',
-                        action='store_false',
-                        dest='process_groups')
-    parser.add_argument('--strategy',
-                        help="whether to fetch and sync the Adobe directory against the customer directory "
-                             "or just to push each customer user to the Adobe side.  Default is to fetch and sync.",
-                        metavar='sync|push',
-                        dest='strategy')
-    parser.add_argument('-t', '--test-mode',
-                        help='enable test mode (API calls do not execute changes on the Adobe side).',
-                        action='store_true',
-                        dest='test_mode')
-    parser.add_argument('-T', '--no-test-mode',
-                        help='disable test mode (API calls execute changes on the Adobe side).',
-                        action='store_false',
-                        dest='test_mode')
-    parser.add_argument('--user-filter',
-                        help='limit the selected set of users that may be examined for syncing, with the pattern '
-                             'being a regular expression.',
-                        metavar='pattern',
-                        dest='user_filter')
-    parser.add_argument('--users',
-                        help="specify the users to be considered for sync. Legal values are 'all' (the default), "
-                             "'group names' (one or more specified groups), 'mapped' (all groups listed in "
-                             "the configuration file), 'file f' (a specified input file).",
-                        nargs="+",
-                        metavar=('all|file|mapped|group', 'groups|path-to-file.csv'),
-                        dest='users')
-    parser.add_argument('--update-user-info',
-                        help='user attributes on the Adobe side are updated from the directory.',
-                        action='store_true',
-                        dest='update_user_info')
-    parser.add_argument('--no-update-user-info',
-                        help='user attributes on the Adobe side are not updated from the directory.',
-                        action='store_false',
-                        dest='update_user_info')
-    # make sure the boolean arguments have no default value
-    parser.set_defaults(process_groups=None, test_mode=None, update_user_info=None)
-    return parser.parse_args(args)
+    pass
 
 
 def init_log(logging_config):

--- a/user_sync/app.py
+++ b/user_sync/app.py
@@ -73,6 +73,10 @@ def main():
     NOTE: The defaults documented here can be overridden in `invocation_defaults` in
     `user-sync-config.yml`.  However, any options explicitly set on the command line will
     override any options set in `invocation_defaults`.
+
+    COMMAND HELP:
+
+    user-sync [COMMAND] -h/--help
     """
     pass
 
@@ -193,6 +197,7 @@ def sync(**kwargs):
 
 
 @main.command()
+@click.help_option('-h', '--help')
 @click.option('--root', help="Filename of root user sync config file",
               prompt='Main Config Filename', default='user-sync-config.yml')
 @click.option('--umapi', help="Filename of UMAPI credential config file",
@@ -216,6 +221,7 @@ def example_config(**kwargs):
 
 
 @main.command()
+@click.help_option('-h', '--help')
 def docs():
     """Open user manual in browser"""
     res_file = user_sync.resource.get_resource('manual_url')

--- a/user_sync/app.py
+++ b/user_sync/app.py
@@ -62,15 +62,11 @@ console_log_handler = init_console_log()
 @click.version_option(None, '-v', '--version', message='%(prog)s %(version)s')
 @click.option('--config-file-encoding', 'encoding_name',
               help="encoding of your configuration files",
-              default=user_sync.config.ConfigLoader.config_defaults['config_encoding'],
-              show_default=True,
               type=str,
               nargs=1,
               metavar='encoding-name')
 @click.option('-c', '--config-filename',
               help="path to your main configuration file",
-              default=user_sync.config.ConfigLoader.config_defaults['config_filename'],
-              show_default=True,
               type=str,
               nargs=1,
               metavar='path-to-file')
@@ -84,8 +80,6 @@ console_log_handler = init_console_log()
                    "'delete' (users and their cloud storage), ",
               cls=user_sync.cli.OptionMulti,
               type=list,
-              show_default=True,
-              default=['preserve'],
               metavar='exclude|preserve|delete|remove|remove-adobe-groups|write-file [path-to-file.csv]')
 @click.option('--adobe-only-user-list',
               help="instead of computing Adobe-only users (Adobe users with no matching users "
@@ -102,32 +96,24 @@ console_log_handler = init_console_log()
                    "the configuration file)",
               cls=user_sync.cli.OptionMulti,
               type=list,
-              show_default=True,
-              default=['all'],
               metavar='all|mapped|group [group list]')
 @click.option('--connector',
               help='specify a connector to use; default is LDAP (or CSV if --users file is specified)',
               cls=user_sync.cli.OptionMulti,
               type=list,
-              show_default=True,
-              default=['ldap'],
               metavar='ldap|okta|csv [path-to-file.csv]')
 @click.option('--process-groups/--no-process-groups',
               help='if membership in mapped groups differs between the enterprise directory and Adobe sides, '
                    'the group membership is updated on the Adobe side so that the memberships in mapped '
-                   'groups match those on the enterprise directory side.',
-              default=False)
+                   'groups match those on the enterprise directory side.')
 @click.option('--strategy',
               help="whether to fetch and sync the Adobe directory against the customer directory "
                    "or just to push each customer user to the Adobe side.  Default is to fetch and sync.",
               nargs=1,
               type=str,
-              metavar='sync|push',
-              default='sync',
-              show_default=True)
+              metavar='sync|push')
 @click.option('-t/-T', '--test-mode/--no-test-mode',
-              help='enable test mode (API calls do not execute changes on the Adobe side).',
-              default=False)
+              help='enable test mode (API calls do not execute changes on the Adobe side).')
 @click.option('--user-filter',
               help='limit the selected set of users that may be examined for syncing, with the pattern '
                    'being a regular expression.',
@@ -140,12 +126,9 @@ console_log_handler = init_console_log()
                    "the configuration file), 'file f' (a specified input file).",
               cls=user_sync.cli.OptionMulti,
               type=list,
-              show_default=True,
-              default=['all'],
               metavar='all|file|mapped|group [group list or path-to-file.csv]')
 @click.option('--update-user-info/--no-update-user-info',
-              help='user attributes on the Adobe side are updated from the directory.',
-              default=False)
+              help='user attributes on the Adobe side are updated from the directory.')
 def main(**kwargs):
     """User Sync from Adobe
 
@@ -197,15 +180,6 @@ def main(**kwargs):
     finally:
         if run_stats is not None:
             run_stats.log_end(logger)
-
-
-def process_args():
-    """Define and parse the command-line (or passed) args.
-
-    All of the arg defaults are actually held in the config module or config files,
-    and the command line is just used to override those, so we don't define defaults here.
-    """
-    pass
 
 
 def init_log(logging_config):

--- a/user_sync/cli.py
+++ b/user_sync/cli.py
@@ -1,0 +1,39 @@
+import click
+
+
+class OptionMulti(click.Option):
+    """
+    click.Option subclass to allow multi-value options of variable length
+    """
+    def __init__(self, *args, **kwargs):
+        nargs = kwargs.pop('nargs', -1)
+        assert nargs == -1, 'nargs, if set, must be -1 not {}'.format(nargs)
+        super(OptionMulti, self).__init__(*args, **kwargs)
+        self._previous_parser_process = None
+        self._eat_all_parser = None
+
+    def add_to_parser(self, parser, ctx):
+        def parser_process(value, state):
+            # method to hook to the parser.process
+            done = False
+            value = [value]
+            # grab everything up to the next option
+            while state.rargs and not done:
+                for prefix in self._eat_all_parser.prefixes:
+                    if state.rargs[0].startswith(prefix):
+                        done = True
+                if not done:
+                    value.append(state.rargs.pop(0))
+            value = tuple(value)
+
+            # call the actual process
+            self._previous_parser_process(value, state)
+
+        super(OptionMulti, self).add_to_parser(parser, ctx)
+        for name in self.opts:
+            our_parser = parser._long_opt.get(name) or parser._short_opt.get(name)
+            if our_parser:
+                self._eat_all_parser = our_parser
+                self._previous_parser_process = our_parser.process
+                our_parser.process = parser_process
+                break

--- a/user_sync/config.py
+++ b/user_sync/config.py
@@ -57,14 +57,14 @@ class ConfigLoader(object):
         'users': ['all'],
     }
 
-    def __init__(self, arg_obj):
+    def __init__(self, args):
         """
         Load the config files and invocation options.
 
-        :type arg_obj: argparse.Namespace
+        :type args: dict
         """
         self.logger = logging.getLogger('config')
-        self.args = vars(arg_obj)
+        self.args = args
         self.main_config = self.load_main_config()
         self.invocation_options = self.load_invocation_options()
         self.directory_groups = self.load_directory_groups()

--- a/user_sync/config.py
+++ b/user_sync/config.py
@@ -48,7 +48,9 @@ class ConfigLoader(object):
         'adobe_only_user_action': ['preserve'],
         'adobe_only_user_list': None,
         'adobe_users': ['all'],
+        'config_filename': 'user-sync-config.yml',
         'connector': ['ldap'],
+        'encoding_name': 'utf8',
         'process_groups': False,
         'strategy': 'sync',
         'test_mode': False,
@@ -91,6 +93,7 @@ class ConfigLoader(object):
         """Merge the invocation option defaults with overrides from the main config and the command line.
         :rtype: dict
         """
+
         # copy instead of direct assignment to preserve original invocation_defaults object
         # otherwise, setting options also sets invocation_defaults (same memory ref)
         options = self.invocation_defaults.copy()
@@ -112,11 +115,17 @@ class ConfigLoader(object):
                     if val:
                         options[k] = val
 
+        # now handle overrides from CLI options
+        for k, arg_val in self.args.items():
+            if arg_val is None:
+                continue
+            options[k] = arg_val
+
         # now process command line options.  the order of these is important,
         # because options processed later depend on the values of those processed earlier
 
         # --connector
-        connector_spec = self.args['connector'] or options['connector']
+        connector_spec = options['connector']
         connector_type = user_sync.helper.normalize_string(connector_spec[0])
         if connector_type in ["ldap", "okta"]:
             if len(connector_spec) > 1:
@@ -131,33 +140,12 @@ class ConfigLoader(object):
         else:
             raise AssertionException('Unknown connector type: %s' % connector_type)
 
-        # --process-groups
-        if self.args['process_groups'] is not None:
-            options['process_groups'] = self.args['process_groups']
-
-        # --strategy
-        if user_sync.helper.normalize_string(self.args['strategy'] or options['strategy']) == 'push':
-            options['strategy'] = 'push'
-
-        # --test-mode
-        if self.args['test_mode'] is not None:
-            options['test_mode'] = self.args['test_mode']
-
-        # --update-user-info
-        if self.args['update_user_info'] is not None:
-            options['update_user_info'] = self.args['update_user_info']
-
         # --adobe-only-user-action
         if options['strategy'] == 'push':
-            if self.args['adobe_only_user_action']:
-                raise AssertionException('You cannot specify --adobe-only-user-action when using "push" strategy')
+            options['adobe_only_user_action'] = None
             self.logger.info("Strategy push: ignoring default adobe-only-user-action")
         else:
-            if self.args['adobe_only_user_action']:
-                adobe_action_spec = self.args['adobe_only_user_action']
-                options['adobe_only_user_action'] = self.args['adobe_only_user_action']
-            else:
-                adobe_action_spec = options['adobe_only_user_action']
+            adobe_action_spec = options['adobe_only_user_action']
             adobe_action = user_sync.helper.normalize_string(adobe_action_spec[0])
             if adobe_action == 'preserve':
                 pass  # no option settings needed
@@ -177,32 +165,20 @@ class ConfigLoader(object):
                 raise AssertionException('Unknown option "%s" for adobe-only-user-action' % adobe_action)
 
         # --users and --adobe-only-user-list conflict with each other, so we need to disambiguate.
-        # Argument specifications override configuration options, so you must have one or the other
-        # either as an argument or as a configured default.  For a complete check, we need to compare against
-        # BOTH the args values AND the options values (in order to catch the invocation defaults).
-        if (self.args['users'] or (options['users'] and options['users'] != self.invocation_defaults['users'])) \
-                and (self.args['adobe_only_user_list'] or options['adobe_only_user_list']):
-            # specifying both --users and --adobe-only-user-list is an error
-            raise AssertionException('You cannot specify both a --users arg and an --adobe-only-user-list arg')
-        elif self.args['users']:
-            # specifying --users overrides the configuration file default for this option
-            options['users'] = self.args['users']
-            users_spec = self.args['users']
-            stray_list_input_path = None
-        elif self.args['adobe_only_user_list']:
+
+        stray_list_input_path = None
+        if options['adobe_only_user_list']:
             # specifying --adobe-only-user-list overrides the configuration file default for --users
             if options['strategy'] == 'push':
                 raise AssertionException('You cannot specify --adobe-only-user-list when using "push" strategy')
-            users_spec = None
-            stray_list_input_path = self.args['adobe_only_user_list']
-        elif options['adobe_only_user_list']:
-            users_spec = None
+            options['users'] = None
+            self.logger.info("Adobe-only user list specified, ignoring 'users' setting")
             stray_list_input_path = options['adobe_only_user_list']
-        elif options['users']:
+
+        users_spec = None
+
+        if options['users'] is not None:
             users_spec = options['users']
-            stray_list_input_path = None            
-        else:
-            raise AssertionException('You must specify either a "users" option or an "adobe-only-user-list" option.')
 
         # --users
         if users_spec:
@@ -227,10 +203,8 @@ class ConfigLoader(object):
                 raise AssertionException('Unknown option "%s" for users' % users_action)
 
         # --adobe-only-user-list
-        if options['strategy'] == 'push':
-            self.logger.info("Strategy push: ignoring default adobe-only-user-list")
-        elif stray_list_input_path:
-            if options.get('stray_list_output_path'):
+        if stray_list_input_path:
+            if options['stray_list_output_path'] is not None:
                 raise AssertionException('You cannot specify both an adobe-only-user-list (%s) and '
                                          'an adobe-only-user-action of "write-file"')
             # don't read the directory when processing from the stray list
@@ -239,28 +213,22 @@ class ConfigLoader(object):
 
         # --user-filter
         if stray_list_input_path:
-            if self.args['user_filter']:
-                raise AssertionException('You cannot specify --user-filter when using an adobe-only-user-list')
+            options['user_filter'] = None
             self.logger.info("adobe-only-user-list specified, so ignoring default user filter specification")
-        else:
-            if self.args['user_filter'] is not None:
-                options['user_filter'] = self.args['user_filter']
+
+        if options['user_filter'] is not None:
             username_filter_pattern = options['user_filter']
-            if username_filter_pattern:
-                try:
-                    compiled_expression = re.compile(r'\A' + username_filter_pattern + r'\Z', re.IGNORECASE)
-                except Exception as e:
-                    raise AssertionException("Bad regular expression in user filter: %s reason: %s" %
-                                             (username_filter_pattern, e))
-                options['username_filter_regex'] = compiled_expression
+            try:
+                compiled_expression = re.compile(r'\A' + username_filter_pattern + r'\Z', re.IGNORECASE)
+            except Exception as e:
+                raise AssertionException("Bad regular expression in user filter: %s reason: %s" %
+                                         (username_filter_pattern, e))
+            options['username_filter_regex'] = compiled_expression
 
         # --adobe-users
-        if self.args['adobe_users'] is not None:
-            adobe_users_spec = options['adobe_users'] = self.args['adobe_users']
-        elif options['adobe_users'] is not None:
+        adobe_users_spec = None
+        if options['adobe_users'] is not None:
             adobe_users_spec = options['adobe_users']
-        else:
-            adobe_users_spec = None
 
         if adobe_users_spec is not None:
             adobe_users_action = user_sync.helper.normalize_string(adobe_users_spec[0])

--- a/user_sync/resources/manual_url
+++ b/user_sync/resources/manual_url
@@ -1,0 +1,1 @@
+https://adobe-apiplatform.github.io/user-sync.py/en/user-manual/


### PR DESCRIPTION
Refactor CLI option handling to use [Click](https://click.palletsprojects.com/en/7.x/).  This introduces subcommands - optional pieces of additional functionality to make the Sync Tool more useful as a standalone application.

Specifically, this update implements the following subcommands:

* **sync** - Run user sync (**default**)
* **example-config** - Generate example config files for main config, UMAPI connector and LDAP connector (will prompt for filenames if filename options are not specified - defaults are the usual filenames)
* **docs** - Open the User Manual with the system's default URL handler (generally the default browser)

These are invoked in this manner - 

```sh
$ user-sync [command] [options]
```

e.g.

```sh
$ user-sync example-config --root user-sync-config.yml --umapi connector-umapi-yml --ldap connector-ldap.yml
```

**sync** is the default command, so if no command is specified, the tool will still run user sync.  This is necessary for maintaining backwards compatibility.

This update depends on the resource manager (see #481).  I've merged changes from `feature/resource-manager` to the click branch.

Build Updates

* Introduce `.build/pre_build.py` for bundling dynamic resources to the `resources` package.  The example configs are bundled here because they should not be committed to source control (since they are already committed in the top-level `examples` directory)
* update `setup.py` to find `resources` package and ensure that resources are included in the pex file (via the `package_data` parameter to `setup()`)
* update Makefile to run `pre_build.py` before building the pex file

Additional Notes

* `ConfigLoader.load_invocation_options()` was cleaned up.  It now applies CLI option overrides in a single pass, eliminating the need to resolve each override individually for each CLI option.  This changes the way that certain conflicting options are resolved - in a couple of cases, it will decide which option to override and continue processing options, where previously it would throw an exception.  It will log messages in these cases.