### PR TITLE
fix CSV adapter by popping none and not setting empty to none for py2

### DIFF
--- a/user_sync/helper.py
+++ b/user_sync/helper.py
@@ -116,7 +116,7 @@ class CSVAdapter:
                         newrow = {}
                         for key, val in six.iteritems(row):
                             newrow[key.decode(encoding, 'strict')] = val.decode(encoding, 'strict') if val else val
-                        row = newrow
+                        yield newrow
                     yield row
             except UnicodeError as e:
                 raise AssertionException("Encoding error in file '%s': %s" % (file_path, e))

--- a/user_sync/helper.py
+++ b/user_sync/helper.py
@@ -113,9 +113,10 @@ class CSVAdapter:
                 for row in reader:
                     row.pop(None, None)
                     if is_py2():
+                        newrow = {}
                         for key, val in six.iteritems(row):
-                            row[key.decode(encoding, 'strict')] = val.decode(encoding, 'strict') if val else val
-
+                            newrow[key.decode(encoding, 'strict')] = val.decode(encoding, 'strict') if val else val
+                        row = newrow
                     yield row
             except UnicodeError as e:
                 raise AssertionException("Encoding error in file '%s': %s" % (file_path, e))

--- a/user_sync/helper.py
+++ b/user_sync/helper.py
@@ -111,12 +111,11 @@ class CSVAdapter:
                     if len(unrecognized_column_names) > 0 and logger is not None:
                         logger.warn("In file '%s': unrecognized column names: %s", file_path, unrecognized_column_names)
                 for row in reader:
+                    row.pop(None, None)
                     if is_py2():
-                        # in py2, we need to decode both the column names *and* the values
-                        newrow = {}
                         for key, val in six.iteritems(row):
-                            newrow[key.decode(encoding, 'strict')] = val.decode(encoding, 'strict') if val else None
-                        row = newrow
+                            row[key.decode(encoding, 'strict')] = val.decode(encoding, 'strict') if val else val
+
                     yield row
             except UnicodeError as e:
                 raise AssertionException("Encoding error in file '%s': %s" % (file_path, e))


### PR DESCRIPTION
Currently, keys and values are decoded from CSV if the platform is py2.  In doing so, we set the updated value as None.  However, since this transformation doesn't apply to py3, an empty field (,,) in the CSV comes in as "" for py3, and None for py2.  The for loop ought to be adjusted for this.  This essentially means setting empty values to themselves instead of None - this way, CSV data is preserved in both py2 and py3 cases.

```python
row[key.decode(encoding, 'strict')] = val.decode(encoding, 'strict') if val else val
```

A second related issue is that this for loop will throw an exception if there are more fields than column headers for a row.  In python 2, this will throw:
                      
for key, val in six.iteritems(row):
>    row[key.decode(encoding, 'strict')] = val.decode(encoding, 'strict') if val else val
E      AttributeError: 'list' object has no attribute 'decode'
OR, if it's just over by 1 field
E      AttributeError: 'Nonetype' object has no attribute 'decode'

Because decode is called on all fields without checkking.  The solution is simple - we just need to pop None keys from the dictionary for py2 AND py3 since we don't want them anyways:

```python
for row in reader:
	row.pop(None, None)
``` 

Tests for this issue will be merged onto DME testing branch when the issue is resolved
