### PR TITLE
Looks like yield is releasing double rows for py2 - this works

### DIFF
--- a/user_sync/helper.py
+++ b/user_sync/helper.py
@@ -116,7 +116,7 @@ class CSVAdapter:
                         newrow = {}
                         for key, val in six.iteritems(row):
                             newrow[key.decode(encoding, 'strict')] = val.decode(encoding, 'strict') if val else val
-                        yield newrow
+                        row = newrow
                     yield row
             except UnicodeError as e:
                 raise AssertionException("Encoding error in file '%s': %s" % (file_path, e))

--- a/user_sync/helper.py
+++ b/user_sync/helper.py
@@ -116,8 +116,9 @@ class CSVAdapter:
                         newrow = {}
                         for key, val in six.iteritems(row):
                             newrow[key.decode(encoding, 'strict')] = val.decode(encoding, 'strict') if val else val
-                        row = newrow
-                    yield row
+                        yield newrow
+                    else:
+                        yield row
             except UnicodeError as e:
                 raise AssertionException("Encoding error in file '%s': %s" % (file_path, e))
 


### PR DESCRIPTION
Same as #493
In py2, I think the row is yielded twice.  Somehow this didn't show up until after the merge.