### PR TITLE
Code redundancy fixed on rules.py, line 1319

### DIFF
--- a/user_sync/rules.py
+++ b/user_sync/rules.py
@@ -1316,7 +1316,7 @@ class UmapiTargetInfo(object):
     def add_additional_group(self, rename_group, member_group):
         normalized_rename_group = normalize_string(rename_group)
         if member_group not in self.additional_group_map[normalized_rename_group]:
-            self.additional_group_map[normalize_string(normalized_rename_group)].append(member_group)
+            self.additional_group_map[normalized_rename_group].append(member_group)
 
     def get_additional_group_map(self):
         return self.additional_group_map


### PR DESCRIPTION
Removed the redundant occurrence of the method normalize_string() from rules.py