### PR TITLE
removed unused methods from RuleProcessor.

### DIFF
--- a/user_sync/rules.py
+++ b/user_sync/rules.py
@@ -975,54 +975,6 @@ class RuleProcessor(object):
                 result.add(normalized_group_name)
         return result
 
-    def calculate_groups_to_add(self, umapi_info, user_key, desired_groups):
-        """
-        Return a set of groups that have not been registered to be added.
-        :type umapi_info: UmapiTargetInfo
-        :type user_key: str
-        :type desired_groups: set(str) 
-        """
-        groups_to_add = self.get_new_groups(umapi_info.groups_added_by_user_key, user_key, desired_groups)
-        if desired_groups is not None and self.logger.isEnabledFor(logging.DEBUG):
-            groups_already_added = desired_groups - groups_to_add
-            if groups_already_added:
-                self.logger.debug('Already added groups for user: %s groups: %s', user_key, groups_already_added)
-        return groups_to_add
-
-    def calculate_groups_to_remove(self, umapi_info, user_key, desired_groups):
-        """
-        Return a set of groups that have not been registered to be removed.
-        :type umapi_info: UmapiTargetInfo
-        :type user_key: str
-        :type desired_groups: set(str) 
-        """
-        groups_to_remove = self.get_new_groups(umapi_info.groups_removed_by_user_key, user_key, desired_groups)
-        if desired_groups is not None and self.logger.isEnabledFor(logging.DEBUG):
-            groups_already_removed = desired_groups - groups_to_remove
-            if len(groups_already_removed) > 0:
-                self.logger.debug('Skipped removed groups for user: %s groups: %s', user_key, groups_already_removed)
-        return groups_to_remove
-
-    def get_new_groups(self, current_groups_by_user_key, user_key, desired_groups):
-        """
-        Return a set of groups that have not been registered in the dictionary for the specified user.        
-        :type current_groups_by_user_key: dict(str, set(str))
-        :type user_key: str
-        :type desired_groups: set(str) 
-        """
-        new_groups = None
-        if desired_groups is not None:
-            current_groups = current_groups_by_user_key.get(user_key)
-            if current_groups is not None:
-                new_groups = desired_groups - current_groups
-            else:
-                new_groups = desired_groups
-            if len(new_groups) > 0:
-                if current_groups is None:
-                    current_groups_by_user_key[user_key] = current_groups = set()
-                current_groups |= new_groups
-        return new_groups
-
     def get_user_attribute_difference(self, directory_user, umapi_user):
         differences = {}
         attributes = self.get_user_attributes(directory_user)


### PR DESCRIPTION
Removed unused methods [get_new_groups, calculate_groups_to_add, calculate_groups_to_remove] from  Rules.RuleProcessor. 

These three methods only call themselves and are not used anywhere else in the codebase. 

It looks like this functionality became obsolete when the Enterprise Dashboard was rebranded into the admin console, for reference: issue #95 (https://github.com/adobe-apiplatform/user-sync.py/issues/95).  Which took place ~v1.2rc2.

