### PR TITLE
Fixed group creation bug & re-enable user role mapping in Sign

### DIFF
--- a/user_sync/sign_sync/app.py
+++ b/user_sync/sign_sync/app.py
@@ -45,7 +45,7 @@ def sync_users(sign_obj, sign_groups, connector, user_keys):
     # Create new user groups in sign if not found
     groups_not_found_in_sign = [group for group in group_list if group not in sign_groups]
     if groups_not_found_in_sign:
-        sign_obj.create_sign_group(group_list)
+        sign_obj.create_sign_group(groups_not_found_in_sign)
 
     # Sync users into their groups
     for user in updated_user_list:

--- a/user_sync/sign_sync/connections/sign_connection.py
+++ b/user_sync/sign_sync/connections/sign_connection.py
@@ -286,6 +286,7 @@ class Sign:
         """
 
         privileges = self.check_umapi_privileges(group, user_info)
+        user_info['roles'] = privileges
 
         data = {
             "email": user_info['username'],
@@ -312,8 +313,7 @@ class Sign:
 
         user['sign_group'] = user_data['group']
 
-    @staticmethod
-    def check_umapi_privileges(group, umapi_user_info):
+    def check_umapi_privileges(self, group, umapi_user_info):
         """
         This function will look through the configuration settings and give access privileges access to each user.
         :param group: list[]
@@ -321,20 +321,32 @@ class Sign:
         :return:
         """
 
-        roles = umapi_user_info['roles']
+        # Sort group and set flags
+        sorted_groups = sorted(umapi_user_info['groups'], reverse=True)
+        product_group = self.get_product_profile()[0]
+        group_admin = False
+        account_admin = False
 
-        if roles == 'NORMAL_USER':
-            privileges = ["NORMAL_USER"]
-        elif roles == 'GROUP_ADMIN':
-            if group != umapi_user_info['sign_group']:
-                privileges = ["NORMAL_USER"]
+        # define account and group admin names
+        admin_prefix = '_admin_'
+        target_group_admin_name = admin_prefix + group
+        target_account_admin_name = admin_prefix + product_group
 
-            else:
-                privileges = ['GROUP_ADMIN']
-        elif roles == 'ACCOUNT_ADMIN':
-            privileges = ["ACCOUNT_ADMIN"]
-        else:
+        # Check to see if user is an admin and set flags
+        if target_group_admin_name in sorted_groups:
+            group_admin = True
+        if target_account_admin_name in sorted_groups:
+            account_admin = True
+
+        # Determine which role to give the user based on flags
+        if account_admin and group_admin:
             privileges = ["ACCOUNT_ADMIN", "GROUP_ADMIN"]
+        elif account_admin:
+            privileges = ["ACCOUNT_ADMIN"]
+        elif group_admin:
+            privileges = ["GROUP_ADMIN"]
+        else:
+            privileges = ['NORMAL_USER']
 
         return privileges
 
@@ -367,12 +379,14 @@ class Sign:
         :return:
         """
 
+        product_profile = self.get_product_profile()[0]
+        admin_prefix = '_admin_'
         temp_group = self.get_sign_group()
 
         # Sort the groups and assign the user to first group
         # Sign doesn't support multi group assignment at this time
         for group in sorted(user['groups']):
-            if group != self.product_profile:
+            if group[:7] != admin_prefix and group != product_profile:
                 group_id = temp_group.get(group)
                 if group_id is not None:
                     temp_payload = self.get_user_info(user, group_id, group)
@@ -385,3 +399,4 @@ class Sign:
                         logger.error("!! Adding User To Group Error !! {} \n{}".format(
                             user['email'], res.text))
                         logger.error('!! Reason !! {}'.format(res.reason))
+                break


### PR DESCRIPTION
- Fixed group creation bug. Passed the wrong parameter to the function create_sign_group. When one group needs to be created it attempted to create all user groups. 

- Re-enabled role mapping.
> User Group Admin = Sign Group Admin
> Product Group Admin = Sign Account Admin
> Anything else = Sign Normal User

- Fixed logging bug for role changes. The user role was never updated, so it would always show the opposite roles when logging.