### PR TITLE
use jeepney 0.4 for py 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,12 +56,14 @@ setup(name='user-sync',
           'umapi-client>=2.12',
           'click',
           'click-default-group',
-          'jeepney==0.4;python_version>="3"'
       ],
       extras_require={
+          ':python_version>="3" and (sys_platform=="linux" or sys_platform=="linux2")':[
+              'jeepney==0.4'
+          ],
           ':sys_platform=="linux" or sys_platform=="linux2"': [
               'secretstorage',
-              'dbus-python'
+              'dbus-python',
           ],
           ':sys_platform=="win32"': [
               'pywin32-ctypes'

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(name='user-sync',
           'umapi-client>=2.12',
           'click',
           'click-default-group',
+          'jeepney==0.4;python_version>="3"'
       ],
       extras_require={
           ':sys_platform=="linux" or sys_platform=="linux2"': [


### PR DESCRIPTION
The ubuntu 3.6 build is failing across the board because the latest jeepney version (released Aug 11, 2019) seems to be broken for ubuntu.  Pex  reports:


wheel.install.BadWheelFile: No expected hash for file 'jeepney-0.4.1.dist-info/tmp/tmp4trcl86h/jeepney-0.4.1/LICENSE'

This fix overrides jeepney to previous version which works on all platforms.