### PR TITLE
Correct spelling on extensions_config.yml

### DIFF
--- a/docs/en/user-manual/advanced_configuration.md
+++ b/docs/en/user-manual/advanced_configuration.md
@@ -202,7 +202,7 @@ configuration file in the `directory_users` section:
 
 ```
 directory_users:
-  extension: extenstions_config.yml  # reference to file with custom mapping information
+  extension: extensions_config.yml  # reference to file with custom mapping information
 ```
 
 Custom attribute handling is performed for each user, so the

--- a/docs/en/user-manual/advanced_configuration.md
+++ b/docs/en/user-manual/advanced_configuration.md
@@ -202,7 +202,7 @@ configuration file in the `directory_users` section:
 
 ```
 directory_users:
-  extension: extensions_config.yml  # reference to file with custom mapping information
+  extension: extension_config.yml  # reference to file with custom mapping information
 ```
 
 Custom attribute handling is performed for each user, so the


### PR DESCRIPTION
The file name for extensions_config.yml was spelled incorrectly.  This corrects that.