### PR TITLE
jeepney fix no longer needed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,9 +58,6 @@ setup(name='user-sync',
           'click-default-group',
       ],
       extras_require={
-          ':python_version>="3" and (sys_platform=="linux" or sys_platform=="linux2")':[
-              'jeepney==0.4'
-          ],
           ':sys_platform=="linux" or sys_platform=="linux2"': [
               'secretstorage',
               'dbus-python',


### PR DESCRIPTION
Removing the exception in setup.py, as builds now all pass without this, and the restriction is now causing problems with other libraries (secretstorage).

https://travis-ci.org/vossen-adobe/user-sync-fork/builds/635431553
https://ci.appveyor.com/project/vossen-adobe/user-sync-fork/builds/30033522

Example of failure:
https://travis-ci.org/vossen-adobe/user-sync-fork/jobs/635423817