### PR TITLE
Centos build issues with dependency and environment vars

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,10 @@ matrix:
     - .travis/build-py27.sh
     - .travis/release.sh
     - python setup.py test
-  - env: OS="centos:7" IMG="centos7" SH="docker exec -t ${IMG} bash -c"
+  - env:
+    - OS="centos:7"
+    - IMG="centos7"
+    - SH="docker exec -t ${IMG} bash -c"
     services:
     - docker
     # for logging purposes
@@ -37,7 +40,10 @@ matrix:
     - $SH .travis/install-centos.sh
     script:
     - $SH .travis/build-py36-centos.sh
-  - env: OS="centos:7" IMG="centos7" SH="docker exec -t ${IMG} bash -c"
+  - env:
+    - OS="centos:7"
+    - IMG="centos7"
+    - SH="docker exec -t ${IMG} bash -c"
     services:
     - docker
     # for logging purposes

--- a/setup.py
+++ b/setup.py
@@ -58,8 +58,8 @@ setup(name='user-sync',
           'click-default-group',
       ],
       extras_require={
-          ':python_version>="3" and (sys_platform=="linux" or sys_platform=="linux2")':[
-              'jeepney==0.4'
+          ':python_version<"3" and (sys_platform=="linux" or sys_platform=="linux2")':[
+              'more-itertools==4.3.0'
           ],
           ':sys_platform=="linux" or sys_platform=="linux2"': [
               'secretstorage',


### PR DESCRIPTION


Itertools:
https://travis-ci.org/adobe-dmeservices/user-sync.py/jobs/640559555

Force old version for py2 to resolve the pex error:

`**** Failed to install more-itertools-8.1.0 (caused by: NonZeroExit("received exit code 1 during execution of `['/home/travis/virtualenv/python2.7.15/bin/python', '-', 'bdist_wheel', '--dist-dir=/tmp/tmpISjMXd']` while trying to execute `['/home/travis/virtualenv/python2.7.15/bin/python', '-', 'bdist_wheel', '--dist-dir=/tmp/tmpISjMXd']`",)
):
stdout:
stderr:
Traceback (most recent call last):
  File "<stdin>", line 9, in <module>
  File "setup.py", line 5, in <module>
    from more_itertools import __version__
ImportError: cannot import name __version__
pex: Failed to install package at /tmp/tmprqWrCA/more-itertools-8.1.0: Failed to install /tmp/tmprqWrCA/more-itertools-8.1.0
Traceback (most recent call last):
  File "/home/travis/virtualenv/python2.7.15/bin/pex", line 8, in <module>
.
.
.
  File "/home/travis/virtualenv/python2.7.15/lib/python2.7/site-packages/pex/resolver.py", line 258, in build
    raise Untranslateable('Package %s is not translateable by %s' % (package, translator))
pex.resolver.Untranslateable: Package SourcePackage(u'https://files.pythonhosted.org/packages/df/8c/c278395367a46c00d28036143fdc6583db8f98622b83875403f16473509b/more-itertools-8.1.0.tar.gz#sha256=c468adec578380b6281a114cb8a5db34eb1116277da92d7c46f904f0b52d3288') is not translateable by ChainedTranslator(WheelTranslator, EggTranslator, SourceTranslator)
Makefile:19: recipe for target 'pex' failed`


Environment 
https://travis-ci.org/adobe-dmeservices/user-sync.py/jobs/640559556

Reorganize variables to list instead of space delimited - order is properly retained.  SH was being set before IMG causing a null value that results in this error.

Also, this fix resolves https://github.com/adobe-apiplatform/user-sync.py/pull/556 so will close that one.

Setting environment variables from .travis.yml
$ export OS="centos:7"
$ export SH="docker exec -t ${IMG} bash -c"
$ export IMG="centos7"
$ export BUILD_TARGET="pex"
0.01s$ source ~/virtualenv/python3.6/bin/activate
$ python --version
Python 3.6.7
$ pip --version
pip 19.0.3 from /home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/pip (python 3.6)
before_install.1
0.00s$ chmod +x .build/.travis/*.sh
before_install.2
6.96s$ docker run -d --name ${IMG} -v $(pwd):/travis -w /travis -e IMG="${IMG}" -e TRAVIS_TAG="${TRAVIS_TAG}" -e BUILD_TARGET="${BUILD_TARGET}" -e UST_BUILD_EXE=0 -e UST_EXTENSION=1 -e UST_SHELL_EXEC=1 ${OS} tail -f /dev/null
before_install.3
0.06s$ docker ps
0.06s$ $SH .build/.travis/install-centos.sh
Error: No such container: bash
The command "$SH .build/.travis/install-centos.sh" failed and exited with 1 during .