### PR TITLE
Python 2 build issue due to Zipp

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,8 +58,8 @@ setup(name='user-sync',
           'click-default-group',
       ],
       extras_require={
-          ':python_version<"3" and (sys_platform=="linux" or sys_platform=="linux2")':[
-              'more-itertools==4.3.0'
+          ':python_version<"3"':[
+              'zipp==1.1.0',
           ],
           ':sys_platform=="linux" or sys_platform=="linux2"': [
               'secretstorage',


### PR DESCRIPTION
Just as soon as the last build issue was resolved, a new python 2 dependency issue showed up.  Very hard to trace the source of this one, but I'm guessing one of the other deps has tried to use a newer version of zipp.  Coincidentally fixing this version for py2 also resolves the more-itertools problem fixed by the last pr.  

I'm not sure if this has anything to do with it, but zipp made a new release like 45 minutes ago (https://pypi.org/project/zipp/#history)

Setting zip==1.1.0 for python 2 resolves the errors.  1.1.0 was the last version supported on python 2, so I'm not sure what might have changed, but I guess some other package is trying to update it.

This was the error:

Successfully installed pex-1.5.3 setuptools-40.9.0 wheel-0.32.3
python .build/pre_build.py
rm -rf dist
pex -v -o dist/user-sync"" -m user_sync.app \
	-f external \
	--disable-cache \
	--not-zip-safe .
pex: Target package WheelPackage('file:///tmp/tmptRRTKO/zipp-0.0.0-py36-none-any.whl') is not compatible with [('cp27', 'cp27mu', 'manylinux1_x86_64'), ('cp27', 'cp27mu', 'linux_x86_64'), ('cp27', 'none', 'manylinux1_x86_64'), ('cp27', 'none', 'linux_x86_64'), ('py2', 'none', 'manylinux1_x86_64'), ('py2', 'none', 'linux_x86_64'), ('cp27', 'none', 'any'), ('cp2', 'none', 'any'), ('py27', 'none', 'any'), ('py2', 'none', 'any')]
Traceback (most recent call last):
  File "/home/travis/virtualenv/python2.7.15/bin/pex", line 8, in <module>
    sys.exit(main())
  File "/home/travis/virtualenv/python2.7.15/lib/python2.7/site-packages/pex/bin/pex.py", line 735, in main
    pex_builder = build_pex(reqs, options, resolver_options_builder)
  File "/home/travis/virtualenv/python2.7.15/lib/python2.7/site-packages/pex/bin/pex.py", line 664, in build_pex
    for resolved_dist in resolveds:
  File "/home/travis/virtualenv/python2.7.15/lib/python2.7/site-packages/pex/resolver.py", line 566, in resolve_multi
    use_manylinux=use_manylinux):
  File "/home/travis/virtualenv/python2.7.15/lib/python2.7/site-packages/pex/resolver.py", line 502, in resolve
    return resolver.resolve(resolvables_from_iterable(requirements, builder))
  File "/home/travis/virtualenv/python2.7.15/lib/python2.7/site-packages/pex/resolver.py", line 300, in resolve
    dist = self.build(package, resolvable.options)
  File "/home/travis/virtualenv/python2.7.15/lib/python2.7/site-packages/pex/resolver.py", line 258, in build
    raise Untranslateable('Package %s is not translateable by %s' % (package, translator))
pex.resolver.Untranslateable: Package SourcePackage(u'https://files.pythonhosted.org/packages/60/85/668bca4a9ef474ca634c993e768f12bd99af1f06bb90bb2655bc538a967e/zipp-2.2.0.tar.gz#sha256=5c56e330306215cd3553342cfafc73dda2c60792384117893f3a83f8a1209f50') is not translateable by ChainedTranslator(WheelTranslator, EggTranslator, SourceTranslator)
Makefile:19: recipe for target 'pex' failed
make: *** [pex] Error 1