### PR TITLE
Fix for 'invalid attribute type memberOf' at user-level LDAP request

### DIFF
--- a/docs/en/user-manual/advanced_configuration.md
+++ b/docs/en/user-manual/advanced_configuration.md
@@ -742,6 +742,17 @@ targeted Adobe groups.
 **Note:** Additional group mapping will fail if a multiple source groups
 map to the same target group.
 
+### Configure 'dynamic_group_member_attribute'
+
+From User Sync tool 2.5 onward, you are required to mention the `memberOf` 
+LDAP attribute in `connector-ldap.yml`. There is no default value and if 
+`addtional_groups` is defined but `dynamic_group_member_attribute` not defined,
+you would see an warning. Here is example:
+
+```yaml
+dynamic_group_member_attribute: 'memberOf'
+```
+
 ### Additional Group Example
 
 Suppose an Adobe Experience Manager customer would like

--- a/examples/config files - basic/connector-ldap.yml
+++ b/examples/config files - basic/connector-ldap.yml
@@ -92,6 +92,12 @@ group_filter_format: "(&(|(objectCategory=group)(objectClass=groupOfNames)(objec
 # group_member_filter_format: "(memberOf:1.2.840.113556.1.4.1941:={group_dn})"
 group_member_filter_format: "(memberOf={group_dn})"
 
+# (optional) configure dynamic_group_member_attribute with dynamic group mappings 
+# From User Sync tool 2.5.0 onward, if additional_groups defined in user-sync-config.yml 
+# then dynamic_group_member_attribute is required. Here you specify the LDAP attribute 
+# used to filter groups mentioned in dynamic group mappings.
+#dynamic_group_member_attribute: "memberOf"
+
 # (optional) two_steps_lookup (no default)
 #two_steps_lookup:
   # (required) group_member_attribute_name (no default)

--- a/user_sync/app.py
+++ b/user_sync/app.py
@@ -337,7 +337,10 @@ def begin_work(config_loader):
         additional_group_filters = [r['source'] for r in additional_groups]
     if directory_connector is not None:
         directory_connector.state.additional_group_filters = additional_group_filters
-
+        # show error dynamic mappings enabled but 'dynamic_group_member_attribute' is not defined
+        if additional_group_filters and directory_connector.state.options['dynamic_group_member_attribute'] is None:
+            raise AssertionException(
+                "Failed to enable dynamic group mappings. 'dynamic_group_member_attribute' is not defined in config")
     primary_name = '.primary' if secondary_umapi_configs else ''
     umapi_primary_connector = user_sync.connector.umapi.UmapiConnector(primary_name, primary_umapi_config)
     umapi_other_connectors = {}

--- a/user_sync/connector/directory_ldap.py
+++ b/user_sync/connector/directory_ldap.py
@@ -77,6 +77,7 @@ class LDAPDirectoryConnector(object):
         self.user_given_name_formatter = LDAPValueFormatter(options['user_given_name_format'])
         self.user_surname_formatter = LDAPValueFormatter(options['user_surname_format'])
         self.user_country_code_formatter = LDAPValueFormatter(options['user_country_code_format'])
+        self.user_memberof_format_formatter = LDAPValueFormatter(options['user_memberof_format'])
 
         auth_method = options['authentication_method'].lower()
 
@@ -137,6 +138,7 @@ class LDAPDirectoryConnector(object):
         builder.set_string_value('user_given_name_format', six.text_type('{givenName}'))
         builder.set_string_value('user_surname_format', six.text_type('{sn}'))
         builder.set_string_value('user_country_code_format', six.text_type('{c}'))
+        builder.set_string_value('user_memberof_format', six.text_type('{memberOf}'))
         builder.set_string_value('user_identity_type', None)
         builder.set_int_value('search_page_size', 200)
         builder.set_string_value('logger_name', LDAPDirectoryConnector.name)
@@ -310,7 +312,7 @@ class LDAPDirectoryConnector(object):
         user_attribute_names.extend(self.user_email_formatter.get_attribute_names())
         user_attribute_names.extend(self.user_username_formatter.get_attribute_names())
         user_attribute_names.extend(self.user_domain_formatter.get_attribute_names())
-        user_attribute_names.append(six.text_type('memberOf'))
+        user_attribute_names.extend(self.user_memberof_format_formatter.get_attribute_names())
 
         extended_attributes = [six.text_type(attr) for attr in extended_attributes]
         extended_attributes = list(set(extended_attributes) - set(user_attribute_names))

--- a/user_sync/connector/directory_ldap.py
+++ b/user_sync/connector/directory_ldap.py
@@ -517,6 +517,10 @@ class LDAPDirectoryConnector(object):
         :param dn: str
         :return: bool
         """
+        # return true if base_dn is empty string such as global scope and no need to check user_dn is part of base_dn
+        if (not (base_dn and base_dn.strip())):
+            return True
+
         split_base_dn = ldap3.utils.dn.parse_dn(base_dn.lower())
         split_dn = ldap3.utils.dn.parse_dn(dn.lower())
         if split_base_dn == split_dn[-len(split_base_dn):]:


### PR DESCRIPTION
Some OpenLDAP directories do not expect `memberOf` attribute in user-level LDAP request. It now reads memberOf attribute from `user_memberof_format` configuration. It is optional config and accepts `None`. The default value is `{memberOf}`.
#503 