### PR TITLE
skip user from the user sync tool process

### DIFF
--- a/examples/config files - custom attributes and mappings/extension-config.yml
+++ b/examples/config files - custom attributes and mappings/extension-config.yml
@@ -49,12 +49,16 @@ extended_adobe_groups:
 #                         # out: Adobe-side dashboard groups as potentially changed by hook code
 #     hook_storage        # for exclusive use by hook code: initialized to None; persists across per-user calls
 #     logger              # an object of type logging.logger which outputs to the console and/or file log
-#
+#     skip_user()         # If you want to remove any user from the user sync process completely, please add the
+                          # validations and call skip_user(), so that users will be skipped from sync if the
+                          # validations are successful
 after_mapping_hook: |
   bc = source_attributes.get('bc')
   subco = source_attributes.get('subco')
   if bc is not None:
     target_attributes['country'] = bc[0:2]
+  if subco == 'Company 3':
+    skip_user()
   if subco == 'Company 1':
     target_groups.add('Company 1 Users')
   elif subco == 'Company 2':

--- a/user_sync/rules.py
+++ b/user_sync/rules.py
@@ -401,8 +401,9 @@ class RuleProcessor(object):
                 def user_drop_callback():
                     self.get_umapi_info(PRIMARY_UMAPI_NAME).get_desired_groups_by_user_key().pop(user_key)
                     self.directory_user_by_user_key.pop(user_key)
-                    if user_key in filtered_directory_user_by_user_key:
-                        self.filtered_directory_user_by_user_key.pop(user_key)
+                    # if user_key in filtered_directory_user_by_user_key:
+                    #     self.filtered_directory_user_by_user_key.pop(user_key)
+                    self.filtered_directory_user_by_user_key.pop(user_key, None)
                     self.dropped_user_count += 1
                 self.after_mapping_hook_scope['source_attributes'] = directory_user['source_attributes'].copy()
 

--- a/user_sync/rules.py
+++ b/user_sync/rules.py
@@ -401,8 +401,6 @@ class RuleProcessor(object):
                 def user_drop_callback():
                     self.get_umapi_info(PRIMARY_UMAPI_NAME).get_desired_groups_by_user_key().pop(user_key)
                     self.directory_user_by_user_key.pop(user_key)
-                    # if user_key in filtered_directory_user_by_user_key:
-                    #     self.filtered_directory_user_by_user_key.pop(user_key)
                     self.filtered_directory_user_by_user_key.pop(user_key, None)
                     self.dropped_user_count += 1
                 self.after_mapping_hook_scope['source_attributes'] = directory_user['source_attributes'].copy()


### PR DESCRIPTION
Changes has been done in rules.py to remove the user from user sync tool process based on the condition in extension-config.yml file. skip_user() need to be called if the condition satisfied to remove the user in extension-config.yml