### PR TITLE
Fix for #605

### DIFF
--- a/user_sync/app.py
+++ b/user_sync/app.py
@@ -35,6 +35,7 @@ import user_sync.connector.directory
 import user_sync.connector.directory_ldap
 import user_sync.connector.directory_okta
 import user_sync.connector.directory_csv
+import user_sync.connector.directory_adobe_console
 import user_sync.connector.umapi
 import user_sync.encryption
 import user_sync.helper

--- a/user_sync/app.py
+++ b/user_sync/app.py
@@ -37,14 +37,15 @@ import user_sync.connector.directory_okta
 import user_sync.connector.directory_csv
 import user_sync.connector.directory_adobe_console
 import user_sync.connector.umapi
+import user_sync.connector.umapi
 import user_sync.encryption
 import user_sync.helper
 import user_sync.lockfile
 import user_sync.resource
 import user_sync.rules
 
-import user_sync.connector.umapi
 from user_sync.post_sync.manager import PostSyncManager
+import user_sync.post_sync.connectors.sign_sync
 
 from user_sync.error import AssertionException
 from user_sync.version import __version__ as app_version


### PR DESCRIPTION
Fixes #605.  Dynamic import doesn't work correctly in pyinstaller build if we don't pre-import the connectors.