### PR TITLE
User status key error

### DIFF
--- a/tests/test_sign_client.py
+++ b/tests/test_sign_client.py
@@ -1,0 +1,31 @@
+import json
+from unittest import mock
+from requests import Response
+from user_sync.post_sync.connectors.sign_sync.client import SignClient
+
+
+@mock.patch('requests.get')
+@mock.patch('user_sync.post_sync.connectors.sign_sync.client.SignClient._init')
+def test_get_users(mock_client, mock_get):
+    def mock_response(data):
+        r = Response()
+        r.status_code = 200
+        r._content = json.dumps(data).encode()
+        return r
+    config = {
+        'console_org': None,
+        'host': 'example.com',
+        'key': '1234567890',
+        'admin_email': 'example@example.com'
+    }
+    user_list = mock_response({'userInfoList': [{"userId": "active"}, {"userId": "inactive"}, {"userId": "nostatus"}]})
+    active_user = mock_response({'userStatus': 'ACTIVE', 'email': 'active@example.com'})
+    inactive_user = mock_response({'userStatus': 'INACTIVE', 'email': 'inactive@example.com'})
+    no_status_user = mock_response({'email': 'nostatus@example.com'})
+
+    mock_get.side_effect = [user_list, active_user, inactive_user, no_status_user]
+    sc = SignClient(config)
+    sc.api_url = "example.com"
+    users = sc.get_users()
+    assert 'active@example.com' and 'nostatus@example.com' in users
+    assert 'inactive@example.com' not in users

--- a/tests/test_sign_client.py
+++ b/tests/test_sign_client.py
@@ -1,6 +1,8 @@
 import json
 from unittest import mock
+
 from requests import Response
+
 from user_sync.post_sync.connectors.sign_sync.client import SignClient
 
 

--- a/user_sync/post_sync/connectors/sign_sync/client.py
+++ b/user_sync/post_sync/connectors/sign_sync/client.py
@@ -91,11 +91,9 @@ class SignClient:
         """
         if self.api_url is None or self.groups is None:
             self._init()
-        #############
         users = {}
         self.logger.debug('getting list of all Sign users')
         users_res = requests.get(self.api_url + 'users', headers=self.header())
-
         if users_res.status_code != 200:
             raise AssertionException("Error retrieving Sign user list")
         for user_id in map(lambda u: u['userId'], users_res.json()['userInfoList']):
@@ -103,7 +101,8 @@ class SignClient:
             if users_res.status_code != 200:
                 raise AssertionException("Error retrieving details for Sign user '{}'".format(user_id))
             user = user_res.json()
-            if user['userStatus'] != 'ACTIVE':
+            user_status = user.get('userStatus')
+            if user_status and user_status != 'ACTIVE':
                 continue
             if user['email'] == self.admin_email:
                 continue

--- a/user_sync/post_sync/connectors/sign_sync/client.py
+++ b/user_sync/post_sync/connectors/sign_sync/client.py
@@ -91,7 +91,7 @@ class SignClient:
         """
         if self.api_url is None or self.groups is None:
             self._init()
-
+        #############
         users = {}
         self.logger.debug('getting list of all Sign users')
         users_res = requests.get(self.api_url + 'users', headers=self.header())


### PR DESCRIPTION
Fixed bug that would throw error when userStatus wasn't present as a key. Now it will allow the user to be included if the key is missing. Also wrote a unit test for that aspect of the get_users method.

fixes #643