### PR TITLE
Sign post-sync bug fix - email casing difference between umapi and sign users

### DIFF
--- a/tests/test_post_sync.py
+++ b/tests/test_post_sync.py
@@ -1,4 +1,11 @@
+import json
+from unittest import mock
+
 import pytest
+from requests import Response
+
+from user_sync.post_sync import PostSyncConnector
+from user_sync.post_sync.connectors.sign_sync import SignClient, SignConnector
 from user_sync.post_sync.manager import PostSyncData
 
 
@@ -51,3 +58,47 @@ def test_add_remove_groups(example_user):
     delta_groups = example_user['groups'] | set(groups_add)
     delta_groups -= set(groups_remove)
     assert post_sync_data.umapi_data[None][email_id]['groups'] == delta_groups
+
+
+@mock.patch('requests.get')
+@mock.patch('user_sync.post_sync.connectors.sign_sync.client.SignClient._init')
+def test_update_sign_users(mock_client, mock_get, example_user):
+    def mock_response(data):
+        r = Response()
+        r.status_code = 200
+        r._content = json.dumps(data).encode()
+        return r
+    #     user_list = mock_response({'userInfoList': [{"userId": "123"}, {"userId": "456"}]})
+    user_list = mock_response({'userInfoList': [{"userId": "123"}]})
+    user_one = mock_response({'userStatus': 'ACTIVE', 'email': 'user@example.com'})
+    # user_two = mock_response({'userStatus': 'ACTIVE', 'email': 'user2@example.com'})
+    mock_get.side_effect = [user_list, user_one]
+    client_config = {
+                'console_org': None,
+                'host': 'api.na2.echosignstage.com',
+                'key': 'allsortsofgibberish1234567890',
+                'admin_email': 'brian.nickila@gmail.com'
+            }
+    sign_client = SignClient(client_config)
+    sign_client.api_url = "whatever"
+    # sign_users = sign_client.get_users()
+    # assert sign_users is not None
+    connector_config = {
+        'sign_orgs': [{'console_org': None,
+        'host': 'api.na2.echosignstage.com',
+        'key': 'allsortsofgibberish1234567890',
+        'admin_email': 'brian.nickila@gmail.com'}],
+        'entitlement_groups': ['group1']
+    }
+    sign_connector = SignConnector(connector_config)
+    assert isinstance(sign_connector, SignConnector)
+    example_user['email'] = 'User@example.com'
+    assert example_user['email'].lower() != example_user['email']
+    #define replacement should_sync
+    def hello(cls, umapi_user, sign_user, org_name):
+        print('x')
+        #assert sign_user not None
+    sign_connector.should_sync = hello
+    sign_connector.update_sign_users(example_user, sign_client, None)
+    # assert sign_users['user@example.com']['email'] == 'user@example.com'
+    # sign_connector.should_sync replacement method

--- a/user_sync/post_sync/connectors/sign_sync/__init__.py
+++ b/user_sync/post_sync/connectors/sign_sync/__init__.py
@@ -55,7 +55,7 @@ class SignConnector(PostSyncConnector):
     def update_sign_users(self, umapi_users, sign_client, org_name):
         sign_users = sign_client.get_users()
         for _, umapi_user in umapi_users.items():
-            sign_user = sign_users.get(umapi_user['email'])
+            sign_user = sign_users.get(umapi_user['email'].lower())
             if not self.should_sync(umapi_user, sign_user, org_name):
                 continue
 


### PR DESCRIPTION
Fixes issue #632 

The `update_sign_users` method in the SignConnector was skipping sign users if their email had different casing from the UMAPI users. Since the Sign API returns all lowercase emails, this was causing unwanted skips. For example, the loop would start with a sign user "user@example.com." Then it would look up that email from the UMAPI users dictionary. If the corresponding UMAPI user was "User@example.com," there would be no match and the should_sync method would be passed None for the Sign user, thus returning false, thus skipping the rest of the update.

The fix in SignConnector was just a `.lower()`. This PR also includes a unit test which checks the lookup of a Sign user against a UMAPI user with an email address that is identical except for a capital letter.