### PR TITLE
Product profile sign bug

### DIFF
--- a/tests/test_sign_client.py
+++ b/tests/test_sign_client.py
@@ -1,0 +1,18 @@
+from user_sync.post_sync.connectors.sign_sync.__init__ import SignConnector
+
+
+def test_should_sync():
+    client_config = {
+        'console_org': None,
+        'host': 'api.na2.echosignstage.com',
+        'key': 'examplekey',
+        'admin_email': 'admin@example.com'
+    }
+    config = {'sign_orgs': [client_config], 'entitlement_groups': ['example product profile']}
+    sc = SignConnector(config)
+    umapi_user = {'type': 'adobeID', 'groups': ['example product profile_76TT88T-provisioning']}
+    assert sc.should_sync(umapi_user, {}, None)
+    umapi_user['groups'] = ['example product profile', 'other profile']
+    assert sc.should_sync(umapi_user, {}, None)
+    umapi_user['groups'] = ['other profile']
+    assert sc.should_sync(umapi_user, {}, None) == set()

--- a/tests/test_sign_client.py
+++ b/tests/test_sign_client.py
@@ -10,6 +10,7 @@ def test_should_sync():
     }
     config = {'sign_orgs': [client_config], 'entitlement_groups': ['example product profile']}
     sc = SignConnector(config)
+    # Verify that extra characters from umapi profiles is removed when comparing profile names
     umapi_user = {'type': 'adobeID', 'groups': ['example product profile_76TT88T-provisioning']}
     assert sc.should_sync(umapi_user, {}, None)
     umapi_user['groups'] = ['example product profile', 'other profile']

--- a/user_sync/post_sync/connectors/sign_sync/__init__.py
+++ b/user_sync/post_sync/connectors/sign_sync/__init__.py
@@ -122,7 +122,7 @@ class SignConnector(PostSyncConnector):
         # eg. 'Example Product Profile' will come through as 'Example Product Profile_EC79122-provisioning'
         umapi_group = []
         for group in umapi_user['groups']:
-            group_fixed = re.sub("_[A-Za-z0-9]+-provisioning$", '', group)
+            group_fixed = re.sub("_[A-Za-z0-9]+(?i)-provisioning$", '', group)
             if group_fixed != group:
                 self.logger.debug("Likely provisioning group mismatch - overriding group name: {0} -> {1}"
                                   .format(group, group_fixed))

--- a/user_sync/post_sync/connectors/sign_sync/__init__.py
+++ b/user_sync/post_sync/connectors/sign_sync/__init__.py
@@ -122,7 +122,10 @@ class SignConnector(PostSyncConnector):
         # eg. 'Example Product Profile' will come through as 'Example Product Profile_EC79122-provisioning'
         umapi_group = []
         for group in umapi_user['groups']:
-            group = re.sub("_[A-Za-z0-9]+-provisioning$", '', group)
+            group_fixed = re.sub("_[A-Za-z0-9]+-provisioning$", '', group)
+            if group_fixed != group:
+                self.logger.debug("Likely provisioning group mismatch - overriding group name: {0} -> {1}"
+                                  .format(group, group_fixed))
             umapi_group.append(group)
         return sign_user is not None and set(umapi_group) & set(self.entitlement_groups[org_name]) and \
                umapi_user['type'] in self.identity_types

--- a/user_sync/post_sync/connectors/sign_sync/__init__.py
+++ b/user_sync/post_sync/connectors/sign_sync/__init__.py
@@ -126,7 +126,7 @@ class SignConnector(PostSyncConnector):
             if group_fixed != group:
                 self.logger.debug("Likely provisioning group mismatch - overriding group name: {0} -> {1}"
                                   .format(group, group_fixed))
-            umapi_group.append(group)
+            umapi_group.append(group_fixed)
         return sign_user is not None and set(umapi_group) & set(self.entitlement_groups[org_name]) and \
                umapi_user['type'] in self.identity_types
 


### PR DESCRIPTION
Product profiles don't always match when they should due to additional characters being appended to the end of a product profile name in user groups in the umapi response. This fix will remove the appended characters before they are compared. A unit test was created in test_sign_client.py for should_sync to verify the bug fix.

fixes #645