### PR TITLE
Added AssertionException if no key 'connectors' was found in director…

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -125,6 +125,18 @@ def test_additional_groups_config(modify_root_config, cli_args):
     assert addl_groups[1]['source'] in options['additional_groups'][1]['source'].pattern
 
 
+def test_directory_users_config(tmp_config_files, modify_root_config, cli_args):
+
+    # test that if connectors is not present or misspelled, an assertion exception is thrown
+    directory_users = {'not_connectors': {'ldap': 'connector-ldap.yml'}}
+    root_config_file = modify_root_config(['directory_users'], directory_users)
+    args = cli_args({'config_filename': root_config_file})
+    config_loader = ConfigLoader(args)
+    connector_name = 'ldap'
+    with pytest.raises(AssertionException):
+        config_loader.get_directory_connector_options(connector_name)
+
+
 def test_twostep_config(tmp_config_files, modify_ldap_config, cli_args):
     (root_config_file, ldap_config_file, _) = tmp_config_files
     modify_ldap_config(['two_steps_lookup'], {})

--- a/tests/util.py
+++ b/tests/util.py
@@ -4,7 +4,7 @@ import collections
 def update_dict(d, ks, u):
     k, ks = ks[0], ks[1:]
     v = d.get(k)
-    if isinstance(v, collections.Mapping):
+    if isinstance(v, collections.Mapping) and ks:
         d[k] = update_dict(v, ks, u)
     else:
         d[k] = u

--- a/tests/util.py
+++ b/tests/util.py
@@ -4,7 +4,7 @@ import collections
 def update_dict(d, ks, u):
     k, ks = ks[0], ks[1:]
     v = d.get(k)
-    if isinstance(v, collections.Mapping) and ks:
+    if ks and isinstance(v, collections.Mapping):
         d[k] = update_dict(v, ks, u)
     else:
         d[k] = u

--- a/user_sync/config.py
+++ b/user_sync/config.py
@@ -325,7 +325,8 @@ class ConfigLoader(object):
         """
         options = {}
         connectors_config = self.get_directory_connector_configs()
-
+        if connectors_config is None:
+            raise AssertionException("Missing key 'connectors' in directory_users")
         if connector_name != 'csv' and connector_name not in connectors_config.value:
             raise AssertionException("Config file must be specified for connector type :: '{}'".format(connector_name))
 


### PR DESCRIPTION
Added AssertionException to catch the condition of a missing or misspelled connectors key in directory_users in user-sync-config.yml. Also added test to verify. Modified util.py to allow changing key value pair of directory_users.

fixes #644