### PR TITLE
Test mode for Sign sync

### DIFF
--- a/examples/sign/connector-sign-sync.yml
+++ b/examples/sign/connector-sign-sync.yml
@@ -10,7 +10,11 @@ sign_orgs:
     key: "Sign API key"
     # Sign account associated with admin_email value will be skipped
     admin_email: "Admin user associated with key e.g. user@example.com"
-
+      # Test_mode presents post_sync output without performing any updates of users or user groups to the Sign Dashbaord
+      # sign_test_mode possible values are yes or no. (default no)
+      # sign_test_mode is independent of user_sync test mode.
+      # Post Sync option does not run if user_sync tool is in test mode
+      sign_test_mode: no
 # User groups to sync to Adobe Sign
 # Secondary orgs (as defined in user-sync-config.yml) can optionally be targeted
 # NOTE: if targeting a group on a secondary org here, there MUST be at least one entitlement_group

--- a/examples/sign/connector-sign-sync.yml
+++ b/examples/sign/connector-sign-sync.yml
@@ -10,11 +10,11 @@ sign_orgs:
     key: "Sign API key"
     # Sign account associated with admin_email value will be skipped
     admin_email: "Admin user associated with key e.g. user@example.com"
-      # Test_mode presents post_sync output without performing any updates of users or user groups to the Sign Dashbaord
-      # sign_test_mode possible values are yes or no. (default no)
-      # sign_test_mode is independent of user_sync test mode.
-      # Post Sync option does not run if user_sync tool is in test mode
-      sign_test_mode: no
+    # Test_mode presents post_sync output without performing any updates of users or user groups to the Sign Dashbaord
+    # sign_test_mode possible values are yes or no. (default no)
+    # sign_test_mode is independent of user_sync test mode.
+    # Post Sync option does not run if user_sync tool is in test mode
+    sign_test_mode: no
 # User groups to sync to Adobe Sign
 # Secondary orgs (as defined in user-sync-config.yml) can optionally be targeted
 # NOTE: if targeting a group on a secondary org here, there MUST be at least one entitlement_group

--- a/user_sync/app.py
+++ b/user_sync/app.py
@@ -397,7 +397,7 @@ def begin_work(config_loader):
     post_sync_manager = None
     # get post-sync config unconditionally so we don't get an 'unused key' error
     post_sync_config = config_loader.get_post_sync_options()
-    if rule_config['strategy'] == 'sync':
+    if rule_config['strategy'] == 'sync' and directory_connector_module_name is not None:
         if post_sync_config:
             post_sync_manager = PostSyncManager(post_sync_config, rule_config['test_mode'])
             rule_config['extended_attributes'] |= post_sync_manager.get_directory_attributes()

--- a/user_sync/post_sync/connectors/sign_sync/__init__.py
+++ b/user_sync/post_sync/connectors/sign_sync/__init__.py
@@ -43,6 +43,8 @@ class SignConnector(PostSyncConnector):
             self.logger.info("Sign Sync disabled in test mode")
             return
         for org_name, sign_client in self.clients.items():
+            if sign_client.sign_test_mode:
+                self.logger.info("::SIGN TEST MODE::")
             # create any new Sign groups
             for new_group in set(self.user_groups[org_name]) - set(sign_client.sign_groups()):
                 self.logger.info("Creating new Sign group: {}".format(new_group))

--- a/user_sync/post_sync/connectors/sign_sync/client.py
+++ b/user_sync/post_sync/connectors/sign_sync/client.py
@@ -10,13 +10,13 @@ class SignClient:
     DEFAULT_GROUP_NAME = 'default group'
 
     def __init__(self, config):
-        for k in ['host', 'key', 'admin_email', 'sign_test_mode']:
+        for k in ['host', 'key', 'admin_email']:
             if k not in config:
                 raise AssertionException("Key '{}' must be specified for all Sign orgs".format(k))
         self.host = config['host']
         self.key = config['key']
         self.admin_email = config['admin_email']
-        self.sign_test_mode = config['sign_test_mode']
+        self.sign_test_mode = config['sign_test_mode'] if 'sign_test_mode' in config else False
         self.console_org = config['console_org'] if 'console_org' in config else None
         self.api_url = None
         self.groups = None

--- a/user_sync/post_sync/manager.py
+++ b/user_sync/post_sync/manager.py
@@ -83,7 +83,7 @@ class PostSyncData:
 
     def remove_umapi_user(self, org_id, user_key):
         umapi_data = self.umapi_data.get(org_id)
-        if user_key not in umapi_data:
+        if umapi_data is None or user_key not in umapi_data:
             return
         del umapi_data[user_key]
 


### PR DESCRIPTION
fixes #637 
Sign sync to has its own test mode where it will state the changes it plans to make but not execute them. sign_test_mode displays post_sync output without performing any updates. Users and user_groups will not be updated in the Sign Dashboard, but users and user groups to be changed will be displayed.   

Updated connector-sign-sync.yml (comments for clarity and default value if sign_test_mode no) to the following:
 #Test_mode presents post_sync output without performing any updates of users or user groups to the Sign Dashboard
    # sign_test_mode possible values are yes or no. (default no)
    # sign_test_mode is independent of user_sync test mode.
    # Post Sync option does not run if user_sync tool is in test mode
    sign_test_mode: no

Sign_test_mode is independent of user_sync test mode. UST will still need to be run in live mode for this to make sense. The post sync connector is disabled in test mode.