### PR TITLE
removeFromOrg not functionning correctly in some cases

### DIFF
--- a/user_sync/post_sync/connectors/sign_sync/client.py
+++ b/user_sync/post_sync/connectors/sign_sync/client.py
@@ -98,7 +98,7 @@ class SignClient:
         """
         retry_nb = 1
         waiting_time = 20
-        while retry_nb < 6:
+        while retry_nb < 5:
             try:
                 waiting_time *= 3
                 self.logger.debug('Attempt {} to call: {}'.format(retry_nb, url))
@@ -112,7 +112,7 @@ class SignClient:
                     raise AssertionException('')
             except Exception as exp:
                 self.logger.warning('Failed: {}'.format(exp))
-                if retry_nb == 5:
+                if retry_nb == 4:
                     raise AssertionException('Quitting after 3 failed retry attempts')
                 self.logger.warning('Waiting for {} seconds'.format(waiting_time))
                 time.sleep(waiting_time)

--- a/user_sync/rules.py
+++ b/user_sync/rules.py
@@ -968,7 +968,7 @@ class RuleProcessor(object):
         :return:
         """
         email = umapi_user.get('email', '')
-        username = umapi_user.get('username', '')
+        username = umapi_user.get('username', '').lower()
         if '@' in username and username != email:
             self.email_override[username] = email
 


### PR DESCRIPTION
<!-- Don't forget to update the PR title to concisely describe the proposed changes -->

## Summary
* removeFromOrg actions will not work if there is a letter case difference between the Admin Console Username field and the internal dict key used to store information about associated email, in the case where both Email and Username fields contain different email formatted values. 
* The fix is to force lowercase values for usernames before these are getting added as keys to the dict 'self.email_override'

<!-- Document the testing procedure for the PR reviewer. Attach any relevant configuration files and
     document invocation options -->
## Testing Steps
* In Admin Console create a 'supplementary' account that has as an Username an email with some uppercase letters.
* run the UST with '--adobe-only-user-action remove' policy
* you will observe that the JSON body for the removeFromOrg action contains current username value for the "user" statement; normally this is recorded as a failure on UMAPI side and on each run the remove action will be shown and never actually done
* UMAPI works by targeting the account by its email, not its username
* now make a build containing the provided fix and you will observe "user" picking up correctly the email value and the remove actually happening in Admin Console

<!-- REQUIRED: Link to all bugs that this PR fixes, one link per line -->
<!-- If there is no related issue, please create one and link it here before submitting the PR -->
Fixes #649
