### PR TITLE
Typo in connector-umapi.yml

### DIFF
--- a/examples/config files - basic/connector-umapi.yml
+++ b/examples/config files - basic/connector-umapi.yml
@@ -69,7 +69,7 @@ enterprise:
   # The actual credential values are placed in the credential store with the
   # username as the org_id value, and the key name (perhaps called internet 
   # or network address) as one of the values below.
-  #secure_client_id: umapi_client_id
+  #secure_client_id_key: umapi_client_id
   #secure_client_secret_key: umapi_client_secret
   #secure_priv_key_data_key: umapi_private_key_data
   # Note: the Windows credential store generally can't store data as large as a private


### PR DESCRIPTION
The expected string value should be:
secure_client_id_key: umapi_client_id 

Incorrect value was:
 secure_client_id

Fixes #639 
