### PR TITLE
Support Specifying Domain Name for Kerberos Authentication.

### DIFF
--- a/user_sync/connector/directory_ldap.py
+++ b/user_sync/connector/directory_ldap.py
@@ -115,7 +115,7 @@ class LDAPDirectoryConnector(object):
         elif auth_method == 'kerberos':
             if(platform.system() == 'Windows'):
                 from .ldap3_extended.Connection import Connection
-                auth = {'authentication': ldap3.SASL, 'sasl_mechanism': ldap3.GSSAPI}
+                auth = {'sasl_credentials': (True,), 'authentication': ldap3.SASL, 'sasl_mechanism': ldap3.GSSAPI}
                 logger.debug('Connecting to: %s - Authentication Method: Kerberos', options['host'])
             else:
                 raise AssertionException('Kerberos Authentication Method is not supported on this OS. Windows Only')


### PR DESCRIPTION
<!-- Don't forget to update the PR title to concisely describe the proposed changes -->

## Summary

By default the ldap3 library attempts to bind against the service principal for the domain you attempted to connect to. If your target LDAP service uses a round-robin DNS, it’s likely that the hostname you connect to won’t match. This cause it to throw the following error:
```LDAP connection failure: SSPI: InitializeSecurityContext: The specified target is unknown or unreachable```

In this case, you can either specify Domain Controller hostname or force the library to do a reverse DNS lookup.

This PR includes the fix to do a reverse DNS lookup automatically when using Kerberos Authentication Method by simply pass True as the first element in sasl_credentials to do a reverse DNS lookup.

There is no additional configuration end-user have to do. This solution supported Domain Controller FQDN and Domain Name

<!-- Document the testing procedure for the PR reviewer. Attach any relevant configuration files and
     document invocation options -->
## Testing Steps
* Set Authentication Method in Connector-LDAP.yml to Kerberos
* Change Host Value in Connector-LDAP.yml to Domain Name (ldaps://example.com)
* Run UST
* It should authenticate to AD and Pull Users and Groups

<br />

* Set Authentication Method in Connector-LDAP.yml to Kerberos
* Change Host Value in Connector-LDAP.yml to Domain Controller FQDN (ldaps://dc001.example.com)
* Run UST
* It should authenticate to AD and Pull Users and Groups


<!-- REQUIRED: Link to all bugs that this PR fixes, one link per line -->
<!-- If there is no related issue, please create one and link it here before submitting the PR -->
Fixes #654
