### PR TITLE
Bug fix: Prevent start_tls before Bind on LDAPS Connection

### DIFF
--- a/user_sync/connector/directory_ldap.py
+++ b/user_sync/connector/directory_ldap.py
@@ -126,9 +126,10 @@ class LDAPDirectoryConnector(object):
         auto_bind = ldap3.AUTO_BIND_NO_TLS
         if options['require_tls_cert']:
             tls = ldap3.Tls(validate=ssl.CERT_REQUIRED, version=ssl.PROTOCOL_TLSv1_2)
-            auto_bind = ldap3.AUTO_BIND_TLS_BEFORE_BIND
         try:
             server = ldap3.Server(host=options['host'], allowed_referral_hosts=True, tls=tls)
+            if server.ssl is False and tls is not None:
+                auto_bind = ldap3.AUTO_BIND_TLS_BEFORE_BIND
             connection = Connection(server, auto_bind=auto_bind, read_only=True, **auth)
         except Exception as e:
             raise AssertionException('LDAP connection failure: %s' % e)


### PR DESCRIPTION
<!-- Don't forget to update the PR title to concisely describe the proposed changes -->

## Summary
* In the pre-2.8 version of LDAP3 library, binding TLS on Secure LDAP will silently error out but in 2.8+, it will raise an exception and causing it to throw ```automatic start_tls befored bind not successful```. As a solution, if the connection is SSL aka LDAPS, there is no need for TLS before Bind since it already encrypted.


<!-- Document the testing procedure for the PR reviewer. Attach any relevant configuration files and
     document invocation options -->
## Testing Steps
* Set Host to ldaps://
* Set Require_TLS_Cert: True
(Since TLS automatically establishes on bind, this should not throw ```automatic start_tls befored bind not successful``` error anymore.)
* Set Host to ldap://
* Set Require_TLS_Cert: True
( This will force the connection to start_tls before binding on unsecured LDAP (389) )
<!-- REQUIRED: Link to all bugs that this PR fixes, one link per line -->
<!-- If there is no related issue, please create one and link it here before submitting the PR -->
Fixes #656