### PR TITLE
Ssl cert verify v3

### DIFF
--- a/docs/en/user-manual/deployment_best_practices.md
+++ b/docs/en/user-manual/deployment_best_practices.md
@@ -253,24 +253,24 @@ logging:
 
 ### Disabling SSL Verification
 
-In environments where SSL inspection is enforced at the firewall, the UMAPI client can encounter the following error:
+In environments where SSL inspection is enforced at the firewall, the https requests can encounter an error similar to the following:
 
 `CRITICAL main - UMAPI connection to org id 'someUUIDvalue@AdobeOrg' failed: [SSL: CERTIFICATE_VERIFY_FAILED] `
 
-This is because the requests module is not aware of the middle-man certificate required for SSL inspection.  The recommended solution to this problem is to specify a path to the certificate bundle using the  REQUESTS_CA_BUNDLE environment variable (see https://helpx.adobe.com/enterprise/kb/UMAPI-UST.html for details).  However, in some cases following these steps does not solve the problem.  The next logical step is to disable SSL inspection on the firewall for the UMAPI traffic.  If, however, this is not permitted, you may work around the issue by disabling SSL verification for user-sync.  
+This is because the requests module is not aware of the middle-man certificate required for SSL inspection.  The recommended solution to this problem is to specify a path to the certificate bundle using the  REQUESTS_CA_BUNDLE environment variable (see https://helpx.adobe.com/enterprise/kb/UMAPI-UST.html for details).  However, in some cases following these steps does not solve the problem.  The next logical step is to disable SSL inspection on the firewall.  If, however, this is not permitted, you may work around the issue by disabling SSL verification for user-sync.  
 
-Disabling the verification is unsafe, and leaves the umapi client vulnerable to middle man attacks, so it is recommended to  avoid disabling it if at all possible.  The umapi client only ever targets two URLs - the usermanagement endpoint and the ims endpoint - both of which are secure Adobe URL's.  In addition, since this option is only recommended for use in a secure network environment, any potential risk is further mitigated.
+Disabling the verification is unsafe, and leaves requests vulnerable to middle man attacks, so it is recommended to  avoid disabling it if at all possible.  The umapi client only ever targets secure Adobe URL's.  In addition, since this option is only recommended for use in a secure network environment, any potential risk is further mitigated.
 
-To bypass the ssl verification, update the umapi config as follows:
+To bypass the ssl verification, update the user-sync-config.yml as follows:
 
 ```yaml
-server:
+invocation_defaults:
   ssl_verify: False
 ```
 
-During the calls, you will also see  a warning from requests:
+During the calls, you may also see a warning from requests:
 
-"InsecureRequestWarning: Unverified HTTPS request is being made to host 'usermanagement-stage.adobe.io'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
+"InsecureRequestWarning: Unverified HTTPS request is being made to host 'usermanagement.adobe.io'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
   InsecureRequestWarning"
 
 

--- a/docs/en/user-manual/deployment_best_practices.md
+++ b/docs/en/user-manual/deployment_best_practices.md
@@ -265,7 +265,7 @@ To bypass the ssl verification, update the user-sync-config.yml as follows:
 
 ```yaml
 invocation_defaults:
-  ssl_verify: False
+  ssl_cert_verify: False
 ```
 
 During the calls, you may also see a warning from requests:

--- a/examples/config files - basic/connector-umapi.yml
+++ b/examples/config files - basic/connector-umapi.yml
@@ -36,7 +36,6 @@ server:
   #ims_endpoint_jwt: /ims/exchange/jwt
   #timeout: 120
   #retries: 3
-  #ssl_verify: True
 
 # (required) enterprise organization settings
 # You must specify all five of these settings.  Consult the

--- a/examples/config files - basic/user-sync-config.yml
+++ b/examples/config files - basic/user-sync-config.yml
@@ -345,6 +345,8 @@ invocation_defaults:
   process_groups: Yes
   # For argument --strategy, the default is 'sync'.
   strategy: sync
+  # Disables SSL certificate verification.  NOT recommended except for special use cases (see docs).
+  #ssl_cert_verify: Yes
   # For argument --test-mode (or -t), the default is False (live run).
   # if you set this default to True, you can supply the argument
   # --no-test-mode (or -T) to override the default.

--- a/user_sync/app.py
+++ b/user_sync/app.py
@@ -29,6 +29,8 @@ from pathlib import Path
 import click
 import six
 from click_default_group import DefaultGroup
+from urllib3.exceptions import InsecureRequestWarning
+import requests
 
 import user_sync.certgen
 import user_sync.cli
@@ -389,6 +391,13 @@ def begin_work(config_loader):
     """
     directory_groups = config_loader.get_directory_groups()
     rule_config = config_loader.get_rule_options()
+
+    if not rule_config['ssl_cert_verify']:
+      logger.warning("SSL certificate verification is bypassed.  Consider disabling this option and using the "
+                     "REQUESTS_CA_BUNDLE environment variable to specify the PEM firewall bundle...")
+      # Suppress only the single warning from urllib3 needed.
+      # noinspection PyUnresolvedReferences
+      requests.packages.urllib3.disable_warnings(category=InsecureRequestWarning)
 
     # make sure that all the adobe groups are from known umapi connector names
     primary_umapi_config, secondary_umapi_configs = config_loader.get_umapi_options()

--- a/user_sync/config.py
+++ b/user_sync/config.py
@@ -55,6 +55,7 @@ class ConfigLoader(object):
         'encoding_name': 'utf8',
         'exclude_unmapped_users': False,
         'process_groups': False,
+        'ssl_cert_verify': True,
         'strategy': 'sync',
         'test_mode': False,
         'update_user_info': False,
@@ -333,8 +334,11 @@ class ConfigLoader(object):
         if connectors_config is not None:
             connector_item = connectors_config.get_list(connector_name, True)
             options = self.get_dict_from_sources(connector_item)
+            if connector_name == "adobe_console":
+                options['ssl_cert_verify'] = self.invocation_options['ssl_cert_verify']
         options = self.combine_dicts(
             [options, self.invocation_options.get('directory_connector_overridden_options', {})])
+
         return options
 
     def get_directory_groups(self):
@@ -411,6 +415,8 @@ class ConfigLoader(object):
                     raise AssertionException(
                         'Unknown post-sync module: {0} - available are: {1}'.format(m, allowed_modules))
                 post_sync_modules[m] = self.get_dict_from_sources([connectors.pop(m)])
+                post_sync_modules[m]['ssl_cert_verify'] = self.invocation_options['ssl_cert_verify']
+
         except KeyError as e:
             raise AssertionException("Error! Post-sync module " + str(e) + " specified without a configuration file...")
 
@@ -600,6 +606,7 @@ class ConfigLoader(object):
     def create_umapi_options(self, connector_config_sources):
         options = self.get_dict_from_sources(connector_config_sources)
         options['test_mode'] = self.invocation_options['test_mode']
+        options['ssl_cert_verify'] = self.invocation_options['ssl_cert_verify']
         return options
 
     def check_unused_config_keys(self):

--- a/user_sync/connector/directory_adobe_console.py
+++ b/user_sync/connector/directory_adobe_console.py
@@ -68,6 +68,7 @@ class AdobeConsoleConnector(object):
         # Let just ignore this
         builder.set_string_value('user_identity_type', None)
         builder.set_string_value('identity_type_filter', 'all')
+        builder.set_bool_value('ssl_cert_verify', True)
         options = builder.get_options()
 
         if not options['identity_type_filter'] == 'all':
@@ -121,6 +122,7 @@ class AdobeConsoleConnector(object):
                 logger=self.logger,
                 timeout_seconds=float(server_options['timeout']),
                 retry_max_attempts=server_options['retries'] + 1,
+                ssl_verify=options['ssl_cert_verify']
             )
         except Exception as e:
             raise AssertionException("Connection to org %s at endpoint %s failed: %s" % (org_id, um_endpoint, e))

--- a/user_sync/connector/umapi.py
+++ b/user_sync/connector/umapi.py
@@ -67,7 +67,7 @@ class UmapiConnector(object):
         server_builder.set_string_value('ims_endpoint_jwt', '/ims/exchange/jwt')
         server_builder.set_int_value('timeout', 120)
         server_builder.set_int_value('retries', 3)
-        server_builder.set_value('ssl_verify', [None, bool], None)
+        server_builder.set_value('ssl_verify', bool, None)
         options['server'] = server_options = server_builder.get_options()
 
         enterprise_config = caller_config.get_dict_config('enterprise')
@@ -79,7 +79,7 @@ class UmapiConnector(object):
 
         # Override with old umapi entry if present
         if options['server']['ssl_verify'] is not None:
-            options['ssl_cert_verify'] = options['server']['ssl_cert_verify']
+            options['ssl_cert_verify'] = options['server']['ssl_verify']
 
         self.options = options
         self.logger = logger = user_sync.connector.helper.create_logger(options)

--- a/user_sync/connector/umapi.py
+++ b/user_sync/connector/umapi.py
@@ -107,7 +107,7 @@ class UmapiConnector(object):
                 logger=self.logger,
                 timeout_seconds=float(server_options['timeout']),
                 retry_max_attempts=server_options['retries'] + 1,
-                ssl_verify=server_options['ssl_cert_verify']
+                ssl_verify=options['ssl_cert_verify']
             )
         except Exception as e:
             raise AssertionException("Connection to org %s at endpoint %s failed: %s" % (org_id, um_endpoint, e))

--- a/user_sync/post_sync/connectors/sign_sync/__init__.py
+++ b/user_sync/post_sync/connectors/sign_sync/__init__.py
@@ -23,6 +23,8 @@ class SignConnector(PostSyncConnector):
         self.identity_types = sync_config.get_list('identity_types', True)
         if self.identity_types is None:
             self.identity_types = ['adobeID', 'enterpriseID', 'federatedID']
+        connection_config = config_options.get('connection') or {}
+        connection_config['ssl_cert_verify'] = config_options['ssl_cert_verify']
 
         # dict w/ structure - umapi_name -> adobe_group -> [set of roles]
         self.admin_roles = self._admin_role_mapping(sync_config)
@@ -30,7 +32,7 @@ class SignConnector(PostSyncConnector):
         sign_orgs = sync_config.get_list('sign_orgs')
         self.clients = {}
         for sign_org_config in sign_orgs:
-            sign_org_config['connection'] = config_options.get('connection') or {}
+            sign_org_config['connection'] = connection_config
             sign_client = SignClient(sign_org_config)
             self.clients[sign_client.console_org] = sign_client
         self.test_mode = test_mode

--- a/user_sync/post_sync/connectors/sign_sync/__init__.py
+++ b/user_sync/post_sync/connectors/sign_sync/__init__.py
@@ -24,7 +24,7 @@ class SignConnector(PostSyncConnector):
         if self.identity_types is None:
             self.identity_types = ['adobeID', 'enterpriseID', 'federatedID']
         connection_config = config_options.get('connection') or {}
-        connection_config['ssl_cert_verify'] = config_options['ssl_cert_verify']
+        connection_config['ssl_cert_verify'] = config_options.get('ssl_cert_verify')
 
         # dict w/ structure - umapi_name -> adobe_group -> [set of roles]
         self.admin_roles = self._admin_role_mapping(sync_config)

--- a/user_sync/post_sync/connectors/sign_sync/client.py
+++ b/user_sync/post_sync/connectors/sign_sync/client.py
@@ -29,6 +29,7 @@ class SignClient:
         self.concurrency_limit = connection_cfg.get('request_concurrency') or 1
         timeout = connection_cfg.get('timeout') or 120
         self.batch_size = connection_cfg.get('batch_size') or 10000
+        self.ssl_cert_verify = connection_cfg.get('ssl_cert_verify') or True
         self.logger = logging.getLogger(self.logger_name())
         logging.getLogger("urllib3").setLevel(logging.WARNING)
         self.timeout = aiohttp.ClientTimeout(total=None, sock_connect=timeout, sock_read=timeout)

--- a/user_sync/post_sync/connectors/sign_sync/client.py
+++ b/user_sync/post_sync/connectors/sign_sync/client.py
@@ -92,7 +92,7 @@ class SignClient:
             url_path = 'base_uris'
             access_point_key = 'api_access_point'
 
-        result = requests.get(url + url_path, headers=self.header())
+        result = requests.get(url + url_path, headers=self.header(), verify=self.ssl_cert_verify)
         if result.status_code != 200:
             raise AssertionException('Error getting base URI from Sign API, is API key valid?')
 
@@ -253,7 +253,7 @@ class SignClient:
             try:
                 waiting_time *= 3
                 self.logger.debug('Attempt {} to call: {}'.format(retry_nb, url))
-                async with session.request(method=method, url=url, data=data or {}) as r:
+                async with session.request(method=method, url=url, data=data or {}, ssl=self.ssl_cert_verify) as r:
                     if r.status >= 500:
                         raise Exception('{}, Headers: {}'.format(r.status, r.headers))
                     elif r.status == 429:

--- a/user_sync/post_sync/connectors/sign_sync/client.py
+++ b/user_sync/post_sync/connectors/sign_sync/client.py
@@ -29,7 +29,8 @@ class SignClient:
         self.concurrency_limit = connection_cfg.get('request_concurrency') or 1
         timeout = connection_cfg.get('timeout') or 120
         self.batch_size = connection_cfg.get('batch_size') or 10000
-        self.ssl_cert_verify = connection_cfg.get('ssl_cert_verify') or True
+        verify = connection_cfg.get('ssl_cert_verify')
+        self.ssl_cert_verify = False if verify is False else True
         self.logger = logging.getLogger(self.logger_name())
         logging.getLogger("urllib3").setLevel(logging.WARNING)
         self.timeout = aiohttp.ClientTimeout(total=None, sock_connect=timeout, sock_read=timeout)


### PR DESCRIPTION
Replacement for #608 because it was easier to rewrite than modify that PR further

- Move to cover all https connections, not just UMAPI since it doesn't make sense to apply this setting on a per-connector basis. Setting lives in user-sync-config invocation defaults
- Doesn't work with Okta - since okta's requests are external
- Disables verbose warning for every request, and instead displays warning at start of sync
- Raises error with info to switch to new method if found in connector-umapi
- Backwards compatible - existing umapi server config option will be respected

The option is injected in config.py - while I don't like this method of implementation, I think it is the most reasonable in terms of end user experience.  Otherwise, the ssl_cert_verify key would need to be present and disabled in all sign, all umapi, and all adobe console configuration files independently which seems to be awkward and confusing.  I believe this setting should be controlled from a central source, and this will also port to phase 2 in sign-sync-config.