### PR TITLE
Fix commented indentation for auto group create

### DIFF
--- a/examples/config files - basic/user-sync-config.yml
+++ b/examples/config files - basic/user-sync-config.yml
@@ -208,8 +208,8 @@ directory_users:
   #         and the additional_groups functionality.
   #   The --process-groups command argument or equivalent invocation setting must
   #   be enabled for groups to be auto-created
-  # group_sync_options:
-  #   auto_create: False
+  #group_sync_options:
+  #  auto_create: False
 
 # Post-sync connectors are enabled here
 # `modules` specifies by name the modules to be enabled


### PR DESCRIPTION
Remove the extra leading space on commented out auto group create options.  It's been driving me crazy that to make it work you need to both uncomment AND remove a leading space, unlike everything else in the file!
