### PR TITLE
fix for #649

### DIFF
--- a/user_sync/rules.py
+++ b/user_sync/rules.py
@@ -635,8 +635,8 @@ class RuleProcessor(object):
         def get_commands(key):
             """Given a user key, returns the umapi commands targeting that user"""
             id_type, username, domain = self.parse_user_key(key)
-            if '@' in username and username in self.email_override:
-                username = self.email_override[username]
+            if '@' in username and username.lower() in self.email_override:
+                username = self.email_override[username.lower()]
             return user_sync.connector.umapi.Commands(identity_type=id_type, username=username, domain=domain)
 
         # do the secondary umapis first, in case we are deleting user accounts from the primary umapi at the end
@@ -981,8 +981,8 @@ class RuleProcessor(object):
         :return:
         """
         email = umapi_user.get('email', '')
-        username = umapi_user.get('username', '')
-        if '@' in username and username != email:
+        username = umapi_user.get('username', '').lower()
+        if '@' in username and username != email.lower():
             self.email_override[username] = email
 
     @staticmethod


### PR DESCRIPTION
<!-- Don't forget to update the PR title to concisely describe the proposed changes -->

## Summary
 Caused by letter case difference in the keys of self.email_override dict, the username vs email override does not resolve the correct email for the account and the removeFromOrg never happens

<!-- Document the testing procedure for the PR reviewer. Attach any relevant configuration files and
     document invocation options -->
## Testing Steps

-  have in admin console an account that has email != username, and username is formated like an email value. 
- modify the username of this account to have a different letter case than in the local LDAP/directory
- run the UST with '--adobe-only-user-action remove' policy; you will observe that the JSON body for the removeFromOrg action contains current username value for the "user" statement; normally this is recorded as a failure on UMAPI side and on each run the remove action will be shown and never actually done
UMAPI works by targeting the account by its email, not its username
- now make a build containing the provided fix and you will observe "user" picking up correctly the email value and the remove actually happening in Admin Console

<!-- REQUIRED: Link to all bugs that this PR fixes, one link per line -->
<!-- If there is no related issue, please create one and link it here before submitting the PR -->
Fixes #649
