### PR TITLE
Fixed broken link to official docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The [User Sync Documentation](https://adobe-apiplatform.github.io/user-sync.py/)
 
 * Windows, Ubuntu or CentOS server/VM (if using a [pre-built release](https://github.com/adobe-apiplatform/user-sync.py/releases/latest))
 * At least 4GB of available RAM
-* Service account for the User Management API (see the [official docs](https://www.adobe.io/apis/experienceplatform/console/docs.html#!AdobeDocs/adobeio-console/master/integrations.md))
+* Service account for the User Management API (see the [official docs](https://www.adobe.io/authentication/auth-methods.html#!AdobeDocs/adobeio-auth/master/AuthenticationOverview/ServiceAccountIntegration.md))
 * Public/private keys for service account (see the [official docs](https://www.adobe.io/authentication/auth-methods.html#!AdobeDocs/adobeio-auth/master/JWT/JWTCertificate.md))
 
 ## Installation and Use


### PR DESCRIPTION
## Summary
* Service account creation official docs link for User Management API was broken.  Corrected to current service account integration page in official docs.

<!-- Document the testing procedure for the PR reviewer. Attach any relevant configuration files and
     document invocation options -->
## Testing Steps
* Confirmed link went to non-broken page

<!-- REQUIRED: Link to all bugs that this PR fixes, one link per line -->
<!-- If there is no related issue, please create one and link it here before submitting the PR -->
Fixes #733 
