### PR TITLE
continue create actions after max remove limit reached

### DIFF
--- a/user_sync/rules.py
+++ b/user_sync/rules.py
@@ -646,7 +646,7 @@ class RuleProcessor(object):
                 self.logger.critical('Unable to process Adobe-only users, as their count (%s) is larger '
                                      'than the max_adobe_only_users setting (%s)', stray_count, max_missing_option)
                 self.action_summary['primary_strays_processed'] = 0
-                return [], {}
+                return primary_commands, secondary_command_lists
             self.logger.debug("Processing Adobe-only users...")
             return self.manage_strays(primary_commands, secondary_command_lists, umapi_connectors)
 


### PR DESCRIPTION
<!-- Don't forget to update the PR title to concisely describe the proposed changes -->

## Summary
*  because `self.process_strays` returns ([],{}), then there are no other commands to execute in `self.execute_commands`, hence after critical log line no other process continues and Summary is shown

the fix is to continue returning the existing list of commands

<!-- Document the testing procedure for the PR reviewer. Attach any relevant configuration files and
     document invocation options -->
## Testing Steps
* run with same ldap changes as stated in the issue #744

<!-- REQUIRED: Link to all bugs that this PR fixes, one link per line -->
<!-- If there is no related issue, please create one and link it here before submitting the PR -->
Fixes #744
