### PR TITLE
Update sign.py

### DIFF
--- a/user_sync/engine/sign.py
+++ b/user_sync/engine/sign.py
@@ -154,13 +154,13 @@ class SignSyncEngine:
         dir_users_for_org = {}
         self.total_sign_user_count += len(sign_users)
         self.sign_users_by_org[org_name] = sign_users
-        for _, directory_user in directory_users.items():
+        for directory_user_key, directory_user in directory_users.items():
 
             if not self.should_sync(directory_user, org_name):
                 continue
 
-            sign_user = sign_users.get(directory_user['email'].lower())
-            dir_users_for_org[directory_user['email'].lower()] = directory_user
+            sign_user = sign_users.get(directory_user_key)
+            dir_users_for_org[directory_user_key] = directory_user
             assignment_group = self.retrieve_assignment_group(directory_user)
 
             if assignment_group is None:
@@ -168,7 +168,7 @@ class SignSyncEngine:
             user_roles = self.retrieve_admin_role(directory_user)
             if sign_user is None:
                 if sign_connector.create_users:
-                    inactive_user = inactive_sign_users.get(directory_user['email'].lower())
+                    inactive_user = inactive_sign_users.get(directory_user_key)
                     # if Standalone user is inactive, we need to reactivate instead of trying to create new account
                     if inactive_user is not None:
                         try:
@@ -341,7 +341,7 @@ class SignSyncEngine:
         """
         :type directory_user: dict
         """
-        email = directory_user.get('email')
+        email = directory_user.get('email').lower()
         if email:
             return six.text_type(email)
         return None

--- a/user_sync/engine/sign.py
+++ b/user_sync/engine/sign.py
@@ -236,8 +236,9 @@ class SignSyncEngine:
         sign_connector.update_users(users_update_list)
         sign_connector.update_user_groups(user_groups_update_list)
         self.sign_only_users_by_org[org_name] = {}
+        dir_users_in_org = map(lambda x: x.lower(), dir_users_for_org.keys())
         for user, data in sign_users.items():
-            if user not in map(lambda x: x.lower(), dir_users_for_org.keys()):
+            if user not in dir_users_in_org:
                 self.total_sign_only_user_count += 1
                 self.sign_only_users_by_org[org_name][user] = data
 

--- a/user_sync/engine/sign.py
+++ b/user_sync/engine/sign.py
@@ -237,7 +237,7 @@ class SignSyncEngine:
         sign_connector.update_user_groups(user_groups_update_list)
         self.sign_only_users_by_org[org_name] = {}
         for user, data in sign_users.items():
-            if user not in dir_users_for_org:
+            if user not in map(lambda x: x.lower(), dir_users_for_org.keys()):
                 self.total_sign_only_user_count += 1
                 self.sign_only_users_by_org[org_name][user] = data
 

--- a/user_sync/engine/sign.py
+++ b/user_sync/engine/sign.py
@@ -159,7 +159,7 @@ class SignSyncEngine:
             if not self.should_sync(directory_user, org_name):
                 continue
 
-            sign_user = sign_users.get(directory_user['email'])
+            sign_user = sign_users.get(directory_user['email'].lower())
             dir_users_for_org[directory_user['email']] = directory_user
             assignment_group = self.retrieve_assignment_group(directory_user)
 
@@ -168,7 +168,7 @@ class SignSyncEngine:
             user_roles = self.retrieve_admin_role(directory_user)
             if sign_user is None:
                 if sign_connector.create_users:
-                    inactive_user = inactive_sign_users.get(directory_user['email'])
+                    inactive_user = inactive_sign_users.get(directory_user['email'].lower())
                     # if Standalone user is inactive, we need to reactivate instead of trying to create new account
                     if inactive_user is not None:
                         try:

--- a/user_sync/engine/sign.py
+++ b/user_sync/engine/sign.py
@@ -341,9 +341,9 @@ class SignSyncEngine:
         """
         :type directory_user: dict
         """
-        email = directory_user.get('email').lower()
+        email = directory_user.get('email')
         if email:
-            return six.text_type(email)
+            return six.text_type(email).lower()
         return None
 
     @staticmethod

--- a/user_sync/engine/sign.py
+++ b/user_sync/engine/sign.py
@@ -160,7 +160,7 @@ class SignSyncEngine:
                 continue
 
             sign_user = sign_users.get(directory_user['email'].lower())
-            dir_users_for_org[directory_user['email']] = directory_user
+            dir_users_for_org[directory_user['email'].lower()] = directory_user
             assignment_group = self.retrieve_assignment_group(directory_user)
 
             if assignment_group is None:
@@ -236,9 +236,8 @@ class SignSyncEngine:
         sign_connector.update_users(users_update_list)
         sign_connector.update_user_groups(user_groups_update_list)
         self.sign_only_users_by_org[org_name] = {}
-        dir_users_in_org = map(lambda x: x.lower(), dir_users_for_org.keys())
         for user, data in sign_users.items():
-            if user not in dir_users_in_org:
+            if user not in dir_users_for_org:
                 self.total_sign_only_user_count += 1
                 self.sign_only_users_by_org[org_name][user] = data
 


### PR DESCRIPTION
<!-- Don't forget to update the PR title to concisely describe the proposed changes -->

## Summary
* difference in letter case between Sign all users extraction and individual user information extraction induces an error of key mismatch between directory_user expected to be matched against extracted sign_user.

<!-- Document the testing procedure for the PR reviewer. Attach any relevant configuration files and
     document invocation options -->
## Testing Steps
* create an account that has upper case letters in Admin Console (GPS Org) and entitle it to Sign
* Let entitlement finish so that the account appears in Default Group
* Assign the account in admin console to a mapped sign goup inside the Sign config file
* run as usual with sign-sync

I only tested for ACTIVE users but I noticed there is similar code for the INACTIVE ones, so I added the fix there as well.

<!-- REQUIRED: Link to all bugs that this PR fixes, one link per line -->
<!-- If there is no related issue, please create one and link it here before submitting the PR -->
Fixes #753
