### PR TITLE
DMESVCS-646:Add new umapi cache attribute

### DIFF
--- a/examples/config files - basic/user-sync-config.yml
+++ b/examples/config files - basic/user-sync-config.yml
@@ -362,3 +362,8 @@ invocation_defaults:
   # For argument --users, the default is 'all'.
   # for CSV input, use an array - ['file', 'users.csv']
   users: mapped
+
+# Storage location of UMAPI cache. This contains cached users, groups and user assignent info
+# The cache will refresh after 24 hours
+cache:
+  path: cache/umapi

--- a/user_sync/config/user_sync.py
+++ b/user_sync/config/user_sync.py
@@ -552,7 +552,6 @@ class UMAPIConfigLoader(ConfigLoader):
         # set the adobe group filter from the mapping, if requested.
         if options.get('adobe_group_mapped') is True:
             options['adobe_group_filter'] = set(AdobeGroup.iter_groups())
-        options['cache'] = self.main_config.get_dict('cache')
         return options
 
     def create_umapi_options(self, connector_config_sources):

--- a/user_sync/config/user_sync.py
+++ b/user_sync/config/user_sync.py
@@ -88,9 +88,6 @@ class UMAPIConfigLoader(ConfigLoader):
         """
         self.logger = logging.getLogger('config')
         self.args = args
-
-
-
         self.main_config = self.load_main_config()
         self.invocation_options = self.load_invocation_options()
         self.directory_groups = self.load_directory_groups()

--- a/user_sync/config/user_sync.py
+++ b/user_sync/config/user_sync.py
@@ -46,6 +46,7 @@ class UMAPIConfigLoader(ConfigLoader):
                              '/directory_users/connectors/*': (True, False, None),
                              '/directory_users/extension': (True, False, None),
                              '/logging/file_log_directory': (False, False, "logs"),
+                             '/cache/path': (False, False, None),
                              }
 
     # like ROOT_CONFIG_PATH_KEYS, but for non-root configuration files
@@ -78,6 +79,7 @@ class UMAPIConfigLoader(ConfigLoader):
         'users': ['all']
     }
 
+    default_cache_path = "cache/umapi"
     def __init__(self, args):
         """
         Load the config files and invocation options.
@@ -86,6 +88,9 @@ class UMAPIConfigLoader(ConfigLoader):
         """
         self.logger = logging.getLogger('config')
         self.args = args
+
+
+
         self.main_config = self.load_main_config()
         self.invocation_options = self.load_invocation_options()
         self.directory_groups = self.load_directory_groups()
@@ -550,7 +555,7 @@ class UMAPIConfigLoader(ConfigLoader):
         # set the adobe group filter from the mapping, if requested.
         if options.get('adobe_group_mapped') is True:
             options['adobe_group_filter'] = set(AdobeGroup.iter_groups())
-
+        options['cache'] = self.main_config.get_dict('cache')
         return options
 
     def create_umapi_options(self, connector_config_sources):

--- a/user_sync/engine/umapi.py
+++ b/user_sync/engine/umapi.py
@@ -168,9 +168,6 @@ class RuleProcessor(object):
                                                                          username_filter_regex.pattern)
             logger.debug('Initialized with options: %s', options_to_report)
 
-        # initialize cache type for umapi
-        self.cache = {}
-
     def run(self, directory_groups, directory_connector, umapi_connectors):
         """
         :type directory_groups: dict(str, list(AdobeGroup)

--- a/user_sync/engine/umapi.py
+++ b/user_sync/engine/umapi.py
@@ -60,6 +60,7 @@ class RuleProcessor(object):
         'test_mode': False,
         'update_user_info': False,
         'username_filter_regex': None,
+        'cache': None,
     }
 
     def __init__(self, caller_options):
@@ -166,6 +167,9 @@ class RuleProcessor(object):
                 options_to_report['username_filter_regex'] = "%s: %s" % (type(username_filter_regex),
                                                                          username_filter_regex.pattern)
             logger.debug('Initialized with options: %s', options_to_report)
+
+        # initialize cache type for umapi
+        self.cache = {}
 
     def run(self, directory_groups, directory_connector, umapi_connectors):
         """


### PR DESCRIPTION
<!-- Don't forget to update the PR title to concisely describe the proposed changes -->

## Summary
* Add new attribute to support UMAPI cache in user-sync-config.yml file. it 
* Add 
 *       cache: 
         path: cache/umapi
* added reference in below files.
*     in user_sync/config/user_sync.py 
        -  default_cache_path = "cache/umapi"
         - options['cache'] = self.main_config.get_dict('cache')
*     in user_sync/engine/umapi.py
        - in default_options  added 'cache': None.
<!-- Document the testing procedure for the PR reviewer. Attach any relevant configuration files and
     document invocation options -->


<!-- REQUIRED: Link to all bugs that this PR fixes, one link per line -->
<!-- If there is no related issue, please create one and link it here before submitting the PR -->
Fixes #768 
