### PR TITLE
Simplify identity type override for ESM trustees

### DIFF
--- a/docs/en/user-manual/advanced_configuration.md
+++ b/docs/en/user-manual/advanced_configuration.md
@@ -204,8 +204,10 @@ enterprise:
 uses_business_id: True
 ```
 
-This essentially overrides the Business ID user type to the type of the user from the primary target, ensuring that
-the full user lifecycle of the user on the secondary target is managed.
+This setting overrides the identity type of all users in the target to the identity type specified in the main sync config file.
+
+**NOTE:** When using this option, it isn't sufficient to exclude users by identity type. Be sure to exclude by group
+(e.g. `_org_admin`) and/or email address.
 
 ## Custom Attributes and Mappings
 

--- a/user_sync/engine/umapi.py
+++ b/user_sync/engine/umapi.py
@@ -113,7 +113,6 @@ class RuleProcessor(object):
         self.primary_users_created = set()
         self.secondary_users_created = set()
         self.updated_user_keys = set()
-        self.primary_users_by_email: dict[str, dict] = {}
 
         # stray key input path comes in, stray_list_output_path goes out
         self.stray_key_map = {}
@@ -922,9 +921,9 @@ class RuleProcessor(object):
         # Walk all the adobe users, getting their group data, matching them with directory users,
         # and adjusting their attribute and group data accordingly.
         for umapi_user in umapi_users:
-            # if target is ESM, then treat existing AdobeID (i.e. businessID) as linked identity type
-            if umapi_connector.uses_business_id and umapi_user['email'] in self.primary_users_by_email:
-                umapi_user['type'] = self.primary_users_by_email[umapi_user['email']]['type']
+            # if target is ESM, then override identity type
+            if umapi_connector.uses_business_id:
+                umapi_user['type'] = self.options['new_account_type']
             # let save adobeID users to a seperate list
             self.filter_adobeID_user(umapi_user)
             # get the basic data about this user; initialize change markers to "no change"
@@ -952,9 +951,6 @@ class RuleProcessor(object):
                 continue
 
             self.map_email_override(umapi_user)
-
-            if umapi_connector.is_primary:
-                self.primary_users_by_email[umapi_user['email']] = umapi_user
 
             directory_user = filtered_directory_user_by_user_key.get(user_key)
             if directory_user is None:


### PR DESCRIPTION
<!-- Don't forget to update the PR title to concisely describe the proposed changes -->

## Summary
* When `uses_business_id` is enabled, just override the identity type without requiring a primary target
* Update docs

<!-- Document the testing procedure for the PR reviewer. Attach any relevant configuration files and
     document invocation options -->
## Testing Steps
* Sync to a T2E trustee with no primary target

<!-- REQUIRED: Link to all bugs that this PR fixes, one link per line -->
<!-- If there is no related issue, please create one and link it here before submitting the PR -->
Fixes #767
