### PR TITLE
Update CredentialManager to accommodate changes to ConfigLoader and ConfigFileLoader

### DIFF
--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -123,7 +123,7 @@ def test_credman_retrieve_revert_valid(test_resources, modify_config):
 
 def test_credman_retrieve_revert_invalid(test_resources, modify_config):
     umapi_config_file = modify_config('umapi', ['enterprise', 'priv_key_path'], test_resources['priv_key'])
-    credman = CredentialManager(umapi_config_file)
+    credman = CredentialManager(test_resources['umapi_root_config'])
     # if credman.store() has not been called first then we can expect the following
     retrieved_creds = credman.retrieve()
     assert retrieved_creds == {}

--- a/user_sync/credentials.py
+++ b/user_sync/credentials.py
@@ -12,6 +12,7 @@ from ruamel.yaml.scalarstring import PreservedScalarString as pss
 
 from user_sync import encryption
 from user_sync.config.common import ConfigFileLoader, ConfigLoader
+from user_sync.config.user_sync import UMAPIConfigLoader
 from user_sync.error import AssertionException
 
 keyrings.cryptfile.cryptfile.CryptFileKeyring.keyring_key = "none"
@@ -68,7 +69,9 @@ class CredentialManager:
         This method will be responsible for reading all config files specified in user-sync-config.yml
         so that credential manager knows which keys and values are needed per file
         """
-        root_cfg = ConfigFileLoader.load_root_config(self.root_config)
+        config_file_loader = ConfigFileLoader('utf8', UMAPIConfigLoader.ROOT_CONFIG_PATH_KEYS,
+                                              UMAPIConfigLoader.SUB_CONFIG_PATH_KEYS)
+        root_cfg = config_file_loader.load_root_config(self.root_config)
         try:
             console_log_level = root_cfg['logging']['console_log_level'].upper()
             self.logger.setLevel(console_log_level)
@@ -88,7 +91,7 @@ class CredentialManager:
                 self.config_files[c[1]] = CredentialConfig.create(c[0], c[1])
 
         if connector_type in ['all', 'umapi']:
-            for u in ConfigLoader.as_list(root_cfg['adobe_users']['connectors']['umapi']):
+            for u in UMAPIConfigLoader.as_list(root_cfg['adobe_users']['connectors']['umapi']):
                 u = list(u.values())[0] if isinstance(u, dict) else u
                 self.config_files[u] = UmapiCredentialConfig(u, auto=self.auto)
 


### PR DESCRIPTION
<!-- Don't forget to update the PR title to concisely describe the proposed changes -->

## Summary
This pull request updates the calls to the ConfigFileLoader.load_root_config() and the ConfigLoader.as_list() methods. load_root_config() is no longer a static method, so this PR creates an instance of the ConfigFileLoader class within CredentialManager to then call that method. The ConfigLoader parent class no longer has a method as_list() since that method has been moved the UMAPIConfigLoader child class, so I made the appropriate changes for that as well.

There was one other test in test-credentials.py that was failing because it was passing connector-umapi.yml as a root config instead of the expected root config, user-sync-config.yml. I think this was just a mistake in how the test was written, so I changed it to use the correct file and it now passes.

<!-- Document the testing procedure for the PR reviewer. Attach any relevant configuration files and
     document invocation options -->
## Testing Steps
I did not create any new tests, but I did change one of them as described above.

<!-- REQUIRED: Link to all bugs that this PR fixes, one link per line -->
<!-- If there is no related issue, please create one and link it here before submitting the PR -->
Fixes #780 
