### PR TITLE
Fix umapi util tests

### DIFF
--- a/tests/test_umapi_util.py
+++ b/tests/test_umapi_util.py
@@ -1,6 +1,7 @@
 import pytest
 
 from user_sync.config.common import ConfigFileLoader, DictConfig
+from user_sync.config.user_sync import UMAPIConfigLoader
 from user_sync.connector.umapi_util import make_auth_dict
 from user_sync.error import AssertionException
 import user_sync.connector.helper

--- a/tests/test_umapi_util.py
+++ b/tests/test_umapi_util.py
@@ -8,8 +8,9 @@ from user_sync.credentials import CredentialConfig, CredentialManager
 
 
 def test_make_auth_dict(test_resources):
-    umapi_config = ConfigFileLoader.load_from_yaml(test_resources['umapi_root_config'], {})
-    umapi_config['enterprise']['priv_key_path'] = test_resources['priv_key']
+    cf_loader = ConfigFileLoader('utf8', UMAPIConfigLoader.ROOT_CONFIG_PATH_KEYS,
+                            UMAPIConfigLoader.SUB_CONFIG_PATH_KEYS)
+    umapi_config = cf_loader.load_from_yaml(test_resources['umapi'], {})
     # note that the private_key fixture is actually just the absolute path to test_private.key in the fixture dir
     umapi_dict_config = DictConfig('enterprise', umapi_config['enterprise'])
     org_id_from_file = umapi_config['enterprise']['org_id']


### PR DESCRIPTION
<!-- Don't forget to update the PR title to concisely describe the proposed changes -->

## Summary
This pull request makes a small update to test_umapi_util.py to accommodate the fact that the ConfigFileLoader.load_from_yaml method is no longer static.

<!-- Document the testing procedure for the PR reviewer. Attach any relevant configuration files and
     document invocation options -->
## Testing Steps
I updated only the test and verified that it now passes.

<!-- REQUIRED: Link to all bugs that this PR fixes, one link per line -->
<!-- If there is no related issue, please create one and link it here before submitting the PR -->
Fixes #783
