### PR TITLE
Update test_dcmanager.py

### DIFF
--- a/tests/test_dcmanager.py
+++ b/tests/test_dcmanager.py
@@ -4,7 +4,8 @@ from unittest import mock
 
 import pytest
 
-from user_sync.config.common import ConfigLoader
+from tests.conftest import default_args
+from user_sync.config.user_sync import UMAPIConfigLoader
 from user_sync.dcmanager import *
 
 
@@ -33,7 +34,7 @@ def multi_config_files(fixture_dir, tmpdir):
 
 
 @pytest.fixture()
-def dc_manager(multi_config_files, modify_root_config):
+def dc_manager(multi_config_files, modify_root_config, default_args):
     # Skip actually creating the connectors
     DirectoryConnectorManager.build_connector = lambda s, v: v
 
@@ -48,7 +49,7 @@ def dc_manager(multi_config_files, modify_root_config):
     modify_root_config(['invocation_defaults', 'connector'], 'multi', merge=False)
 
     # Create the config loader
-    cl = ConfigLoader({'config_filename': multi_config_files['root_config'], 'encoding_name': None})
+    cl = UMAPIConfigLoader(default_args)
 
     # Finally, return the DCM
     return DirectoryConnectorManager(cl)
@@ -110,7 +111,7 @@ def test_common_names_for_connector(dc_manager):
     assert g == {'All Apps', 'Group One'}
 
 
-@mock.patch('user_sync.config.ConfigLoader.get_directory_connector_configs')
+@mock.patch('user_sync.config.user_sync.UMAPIConfigLoader.get_directory_connector_configs')
 def test_build_directory_config_dict(gdcc, dc_manager):
     conn_list = [
         connector_dict('src1', 'ldap', 'path1'),


### PR DESCRIPTION
<!-- Don't forget to update the PR title to concisely describe the proposed changes -->

## Summary
The dc_manager fixture needs to use a UMAPIConfigLoader object instead of a ConfigLoader to reflect updates that have been made to architecture elsewhere in the Sync Tool. There is also a test that uses mock.patch that needs to point to the path of the UMAPIConfigLoader instead of the ConfigLoader.

<!-- Document the testing procedure for the PR reviewer. Attach any relevant configuration files and
     document invocation options -->
## Testing Steps
I updated the fixture and the mock.patch decorator to use UMAPIConfigLoader, then verified that all tests within test_dcmanager.py now pass.

<!-- REQUIRED: Link to all bugs that this PR fixes, one link per line -->
<!-- If there is no related issue, please create one and link it here before submitting the PR -->
Fixes #786 
