### PR TITLE
Remove command line arguments from Windows batch files

### DIFF
--- a/user_sync/resources/shell_scripts/win/Run_UST_Live.bat
+++ b/user_sync/resources/shell_scripts/win/Run_UST_Live.bat
@@ -1,3 +1,3 @@
 mode 155,50
 cd /D "%~dp0"
-user-sync.exe --process-groups --users mapped
+user-sync.exe

--- a/user_sync/resources/shell_scripts/win/Run_UST_Test_Mode.bat
+++ b/user_sync/resources/shell_scripts/win/Run_UST_Test_Mode.bat
@@ -1,4 +1,4 @@
 mode 155,50
 cd /D "%~dp0"
-user-sync.exe --process-groups --users mapped -t
+user-sync.exe -t
 pause


### PR DESCRIPTION
<!-- Don't forget to update the PR title to concisely describe the proposed changes -->

## Summary
This PR simply removes the `process-groups` and `users mapped` arguments from both the test and live Windows batch files. This allows customers to change these options in user-sync-config.yml either directly or with the Configuration Wizard without having the batch file override them.

<!-- Document the testing procedure for the PR reviewer. Attach any relevant configuration files and
     document invocation options -->
## Testing Steps
I did not write any new tests for this PR.

<!-- REQUIRED: Link to all bugs that this PR fixes, one link per line -->
<!-- If there is no related issue, please create one and link it here before submitting the PR -->
Fixes #789 
