### PR TITLE
Add except block for SSLError in Okta connector

### DIFF
--- a/user_sync/connector/directory_okta.py
+++ b/user_sync/connector/directory_okta.py
@@ -19,6 +19,7 @@
 # SOFTWARE.
 
 import okta
+import requests
 import six
 import string
 from okta.framework.OktaError import OktaError
@@ -145,6 +146,9 @@ class OktaDirectoryConnector(DirectoryConnector):
         except OktaError as e:
             self.logger.warning("Unable to query group")
             raise AssertionException("Okta error querying for group: %s" % e)
+        except requests.exceptions.SSLError as ce:
+            if "doesn't match either of '*.okta.com', 'okta.com" in str(ce):
+                raise AssertionException("Invalid hostname: %s" % ce)
 
         if results is None:
             self.logger.warning("No group found for: %s", group)


### PR DESCRIPTION
<!-- Don't forget to update the PR title to concisely describe the proposed changes -->

## Summary
If the host name is formatted incorrectly in connector-okta.yml, it triggers an unhandled exception. This PR adds a block of code to handle the particular exception that gets triggered in that case (namely `requests.exceptions.SSLError`) and raises an AssertionException instead.

<!-- Document the testing procedure for the PR reviewer. Attach any relevant configuration files and
     document invocation options -->
## Testing Steps
I did not write any new tests for this PR.

<!-- REQUIRED: Link to all bugs that this PR fixes, one link per line -->
<!-- If there is no related issue, please create one and link it here before submitting the PR -->
Fixes #601 
