### PR TITLE
Return commands when Adobe-only users are not managed

### DIFF
--- a/user_sync/engine/umapi.py
+++ b/user_sync/engine/umapi.py
@@ -638,6 +638,7 @@ class RuleProcessor(object):
                 return primary_commands, secondary_command_lists
             self.logger.debug("Processing Adobe-only users...")
             return self.manage_strays(primary_commands, secondary_command_lists, umapi_connectors)
+        return primary_commands, secondary_command_lists
 
     def manage_strays(self, primary_commands, secondary_command_lists, umapi_connectors):
         """


### PR DESCRIPTION
<!-- Don't forget to update the PR title to concisely describe the proposed changes -->

## Summary
* If `process_users` is false and `adobe_only_user_action` is set to write file, then `process_strays()` returns null
* This causes crash with stack trace
* See #801 for more info

<!-- Document the testing procedure for the PR reviewer. Attach any relevant configuration files and
     document invocation options -->
## Testing Steps
* Run w/ `--adobe-only-user-action write-file [file path]` and `--no-process-groups`
* When run on v2, observe crash
* Crash should not occur with this fix branch

<!-- REQUIRED: Link to all bugs that this PR fixes, one link per line -->
<!-- If there is no related issue, please create one and link it here before submitting the PR -->
Fixes #801
