### PR TITLE
Update umapi.py

### DIFF
--- a/user_sync/engine/umapi.py
+++ b/user_sync/engine/umapi.py
@@ -1173,6 +1173,9 @@ class RuleProcessor(object):
         for umapi_name in self.stray_key_map:
             for user_key in self.get_stray_keys(umapi_name):
                 id_type, username, domain = self.parse_user_key(user_key)
+                # switch username with email if override in place:
+                if '@' in username and username in self.email_override.keys():
+                    username = self.email_override[username]
                 umapi = umapi_name if umapi_name else ""
                 if secondary_count:
                     row_dict = {'type': id_type, 'username': username, 'domain': domain, 'umapi': umapi}


### PR DESCRIPTION
## Summary
* A fix to handle the remove/delete of accounts with different email than username (both having email formatted values), when the input is a csv list
* Modifies the behaviour so that when writing to csv file (--write-file) contains the mail value of the account instead of the username

<!-- Document the testing procedure for the PR reviewer. Attach any relevant configuration files and
     document invocation options -->
## Testing Steps
* have in admin console an account with different email than username
* run the tool with  `--adobe-only-user-action write-file a.csv` argument
* look inside at the resulting .csv `username` field -> it should be the current account's email, that the API will use further for other action.
* run the tool with `--adobe-only-user-action delete --adobe-only-user-list a.csv` and the account should get deleted from admin console

<!-- REQUIRED: Link to all bugs that this PR fixes, one link per line -->
<!-- If there is no related issue, please create one and link it here before submitting the PR -->
Fixes #808
