### PR TITLE
User update fix

### DIFF
--- a/user_sync/engine/umapi.py
+++ b/user_sync/engine/umapi.py
@@ -1360,6 +1360,37 @@ class UmapiTargetInfo:
 
 
 class MultiIndex:
+    """
+    This data structure replaces the old convention of caching users in a
+    dictionary indexed by a static composite key. The MultiIndex structure
+    consists of a simple list (self.data) consisting of one or more dictionaries
+    that follow a regular structure (e.g. a list of directory users or UMAPI
+    users).
+
+    This list is indexed by one or more keys. Each key should point to one
+    record in self.data.
+
+    When a record is fetched from the index, a record is returned if at least
+    one key matches a record. This allows partial matches - i.e. when retrieving
+    information for a user where the email address matches a record but the
+    username does not (or vice versa).
+
+    Example:
+
+    >>> data = [{"key1": "foo", "key2": "bar", "other": "data"}]
+    >>> mi = MultiIndex(data=data, key_names=["key1", "key2"])
+    >>> mi.get(key1="foo", key2="bar")
+    {"key1": "foo", "key2": "bar", "other": "data"}
+    >>> mi.get(key1="foo", key2="invalid")
+    {"key1": "foo", "key2": "bar", "other": "data"}
+    >>> mi.get(key1="invalid", key2="invalid")
+    None
+
+    MultiIndex supports the addition of new individual records and
+    the ability to update existing records. It does not support
+    deletion because that would require a full reindex for each
+    deletion.
+    """
     def __init__(self, data, key_names):
         self.data = data
         self.key_names = key_names

--- a/user_sync/engine/umapi.py
+++ b/user_sync/engine/umapi.py
@@ -441,7 +441,8 @@ class RuleProcessor(object):
                         raise user_sync.error.AssertionException("Additional group resolution error: {}".format(str(e)))
                     umapi_info.add_mapped_group(rename_group)
                     umapi_info.add_additional_group(rename_group, member_group)
-                    umapi_info.add_desired_group_for(user_key, rename_group)
+                    umapi_info.add_desired_group_for(directory_user['identity_type'], directory_user['domain'],
+                                                     directory_user['email'], directory_user['username'], rename_group)
 
         self.logger.debug('Total directory users after filtering: %d', len(self.filtered_directory_user_index.data))
         if self.logger.isEnabledFor(logging.DEBUG):

--- a/user_sync/engine/umapi.py
+++ b/user_sync/engine/umapi.py
@@ -1408,7 +1408,7 @@ class MultiIndex:
             keys = self.index.get(kn)
             if keys is None:
                 raise KeyError(f"Key '{kn}' not found in index")
-            i = keys.get(k)
+            i = keys.get(k.lower())
             if i is None:
                 continue
             return i
@@ -1423,7 +1423,7 @@ class MultiIndex:
             k = obj.get(kn)
             if k is None:
                 raise KeyError(f"Can't find key '{kn}' on object {obj=}")
-            self.index[kn][k] = i
+            self.index[kn][k.lower()] = i
 
     def add(self, obj):
         i = len(self.data)
@@ -1440,8 +1440,8 @@ class MultiIndex:
         for kn in self.key_names:
             if kn not in obj:
                 raise KeyError(f"Can't find key '{kn}' on object {obj=}")
-            if curr_obj[kn] != obj[kn]:
-                reindex[kn] = (curr_obj[kn], obj[kn])
+            if curr_obj[kn].lower() != obj[kn].lower():
+                reindex[kn] = (curr_obj[kn].lower(), obj[kn].lower())
 
         self.data[i] = obj
         for kn, keys in reindex.items():

--- a/user_sync/engine/umapi.py
+++ b/user_sync/engine/umapi.py
@@ -513,15 +513,18 @@ class RuleProcessor(object):
             else:
                 secondary_adds_by_user_key, update_commands = self.update_umapi_users_for_connector(umapi_info, umapi_connector)
                 secondary_command_lists[umapi_name].extend(update_commands)
-            total_users = len(secondary_adds_by_user_key)
-            for user_key, groups_to_add in secondary_adds_by_user_key.items():
+            total_users = len(secondary_adds_by_user_key.data)
+            for secondary_add in secondary_adds_by_user_key.data:
                 # We only create users who have group mappings in the secondary umapi
-                if groups_to_add:
+                if secondary_add['desired_groups']:
+                    user_key = self.get_user_key(secondary_add['id_type'], secondary_add['username'],
+                                                 secondary_add['domain'], secondary_add['email'])
                     self.secondary_users_created.add(user_key)
                     if user_key not in self.primary_users_created:
                         # We pushed an existing user to a secondary in order to update his groups
                         self.updated_user_keys.add(user_key)
-                    secondary_command_lists[umapi_name].append(self.create_umapi_user(user_key, groups_to_add, umapi_info, umapi_connector.trusted))
+                    secondary_command_lists[umapi_name].append(self.create_umapi_user(user_key, secondary_add['desired_groups'],
+                                                                                      umapi_info, umapi_connector.trusted))
         return primary_commands, secondary_command_lists
 
     def execute_commands(self, command_list, connector):

--- a/user_sync/engine/umapi.py
+++ b/user_sync/engine/umapi.py
@@ -934,10 +934,10 @@ class RuleProcessor(object):
             if not user_key:
                 self.logger.warning("Ignoring umapi user with empty user key: %s", umapi_user)
                 continue
-            if umapi_info.get_umapi_user(user_key) is not None:
+            if umapi_info.get_umapi_user(email=umapi_user['email'], username=umapi_user['username']) is not None:
                 self.logger.debug("Ignoring umapi user. This user has already been processed: %s", umapi_user)
                 continue
-            umapi_info.add_umapi_user(user_key, umapi_user)
+            umapi_info.add_umapi_user(umapi_user)
             attribute_differences = {}
             current_groups = self.normalize_groups(umapi_user.get('groups'))
             groups_to_add = set()
@@ -1273,11 +1273,8 @@ class UmapiTargetInfo:
         self.mapped_groups = set()
         self.non_normalize_mapped_groups = set()
         self.desired_groups_by_user_key = MultiIndex(data=[], key_names=['email', 'username'])
-        self.umapi_user_by_user_key = {}
+        self.umapi_user_by_user_key = MultiIndex(data=[], key_names=['email', 'username'])
         self.umapi_users_loaded = False
-        self.stray_by_user_key = {}
-        self.groups_added_by_user_key = {}
-        self.groups_removed_by_user_key = {}
 
         # keep track of auto-mapped additional groups for conflict tracking.
         # if feature is disabled, this dict will be empty
@@ -1342,21 +1339,18 @@ class UmapiTargetInfo:
             desired_groups_rec['desired_groups'].add(normalized_group_name)
             self.desired_groups_by_user_key.update(desired_groups_rec, email=email, username=username)
 
-    def add_umapi_user(self, user_key, user):
+    def add_umapi_user(self, user):
         """
         :type user_key: str
         :type user: dict
         """
-        self.umapi_user_by_user_key[user_key] = user
+        self.umapi_user_by_user_key.add(user)
 
-    def iter_umapi_users(self):
-        return self.umapi_user_by_user_key.items()
-
-    def get_umapi_user(self, user_key):
+    def get_umapi_user(self, email, username):
         """
         :type user_key: str
         """
-        return self.umapi_user_by_user_key.get(user_key)
+        return self.umapi_user_by_user_key.get(email=email, username=username)
 
     def set_umapi_users_loaded(self):
         self.umapi_users_loaded = True


### PR DESCRIPTION
<!-- Don't forget to update the PR title to concisely describe the proposed changes -->

## Summary

This is to fix a regression found in `v2.8.0` which prevents the sync tool from updating a user's email address. This was likely caused by the introduction of the email address to the static user key.

The fix I propose is to stop indexing user information using this static composite key. It never worked super well because of how the UMAPI and admin console identify users by email address under most circumstances but also require username in others.

I've created a system that indexes user info by multiple keys, but only one key is required to identify a user when looking it up in the index. This is implemented in a new class in the UMAPI engine file called `MultiIndex`.

More information can be found in the class's docstring:

```
    This data structure replaces the old convention of caching users in a
    dictionary indexed by a static composite key. The MultiIndex structure
    consists of a simple list (self.data) consisting of one or more dictionaries
    that follow a regular structure (e.g. a list of directory users or UMAPI
    users).

    This list is indexed by one or more keys. Each key should point to one
    record in self.data.

    When a record is fetched from the index, a record is returned if at least
    one key matches a record. This allows partial matches - i.e. when retrieving
    information for a user where the email address matches a record but the
    username does not (or vice versa).

    Example:

    >>> data = [{"key1": "foo", "key2": "bar", "other": "data"}]
    >>> mi = MultiIndex(data=data, key_names=["key1", "key2"])
    >>> mi.get(key1="foo", key2="bar")
    {"key1": "foo", "key2": "bar", "other": "data"}
    >>> mi.get(key1="foo", key2="invalid")
    {"key1": "foo", "key2": "bar", "other": "data"}
    >>> mi.get(key1="invalid", key2="invalid")
    None

    MultiIndex supports the addition of new individual records and
    the ability to update existing records. It does not support
    deletion because that would require a full reindex for each
    deletion.
```

<!-- Document the testing procedure for the PR reviewer. Attach any relevant configuration files and
     document invocation options -->
## Testing Steps

I've tested this with one UMAPI target, primary + secondary and secondary only (which produces the expected UMAPI errors). I've also tested the update with Adobe-only CSV files (read/write).

<!-- REQUIRED: Link to all bugs that this PR fixes, one link per line -->
<!-- If there is no related issue, please create one and link it here before submitting the PR -->
Fixes #810
