### PR TITLE
Config that controls user information updates

### DIFF
--- a/examples/config files - basic/user-sync-config.yml
+++ b/examples/config files - basic/user-sync-config.yml
@@ -18,6 +18,14 @@ adobe_users:
   connectors:
     umapi: "connector-umapi.yml"
 
+  # Enable or disable user attributes to be updated when `--update-user-info` or `update_user_info` is enabled
+  # `username` updates are disabled by default
+  update_attributes:
+    - firstname
+    - lastname
+    - email
+    # - username
+
 # --- Directory Users Options
 # Governs directory-side behavior and configuration related to the identity source
 # See https://adobe-apiplatform.github.io/user-sync.py/en/user-manual/configuring_user_sync_tool.html#directory_users-config

--- a/tests/fixture/user-sync-config.yml
+++ b/tests/fixture/user-sync-config.yml
@@ -5,6 +5,10 @@ adobe_users:
   exclude_users: null
   connectors:
     umapi: connector-umapi.yml
+  update_attributes:
+    - firstname
+    - lastname
+    - email
 directory_users:
   user_identity_type: federatedID
   default_country_code: US

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -58,6 +58,27 @@ def test_max_adobe_percentage(cleanup, default_args, modify_root_config, cf_load
         UMAPIConfigLoader(default_args).get_engine_options()
 
 
+def test_update_attributes(cleanup, default_args, test_resources, modify_root_config, cf_loader):
+    config = cf_loader.load_root_config(test_resources['umapi_root_config'])
+    assert 'adobe_users' in config and 'update_attributes' in config['adobe_users']
+    assert 'firstname' in config['adobe_users']['update_attributes']
+    assert 'lastname' in config['adobe_users']['update_attributes']
+    assert 'email' in config['adobe_users']['update_attributes']
+    assert 'username' not in config['adobe_users']['update_attributes']
+
+    reset_rule_options()
+    options = UMAPIConfigLoader(default_args).get_engine_options()
+    assert 'update_attributes' in options
+    assert 'firstname' in options['update_attributes']
+    assert 'lastname' in options['update_attributes']
+    assert 'email' in options['update_attributes']
+
+    root_config_file = modify_root_config(['adobe_users', 'update_attributes'], ['firstname', 'lastname', 'foo'])
+    config = cf_loader.load_root_config(root_config_file)
+    reset_rule_options()
+    with pytest.raises(AssertionException):
+        UMAPIConfigLoader(default_args).get_engine_options()
+
 def test_additional_groups_config(cleanup, default_args, modify_root_config, cf_loader):
     addl_groups = [
         {

--- a/user_sync/config/user_sync.py
+++ b/user_sync/config/user_sync.py
@@ -518,6 +518,15 @@ class UMAPIConfigLoader(ConfigLoader):
                 exclude_groups.append(group.get_group_name())
             options['exclude_groups'] = exclude_groups
 
+        update_attributes = adobe_config.get_list('update_attributes', True)
+        valid_attributes = ['firstname', 'lastname', 'email', 'username']
+        if update_attributes is not None:
+            update_attributes = [attr.lower() for attr in update_attributes]
+            for attr in update_attributes:
+                if attr not in valid_attributes:
+                    raise AssertionException(f"'{attr}' is not a valid attribute for user updates")
+            options['update_attributes'] = update_attributes
+
         # get the limits
         limits_config = self.main_config.get_dict_config('limits')
         max_missing = limits_config.get_value('max_adobe_only_users', (int, str), False)

--- a/user_sync/engine/umapi.py
+++ b/user_sync/engine/umapi.py
@@ -1079,6 +1079,9 @@ class RuleProcessor(object):
             else:
                 diff = value != umapi_value
             if diff:
+                if key not in self.options['update_attributes']:
+                    self.logger.warn(f"'{key}' has changed for user '{self.get_umapi_user_key(umapi_user)}', but that attribute isn't configured for updating")
+                    continue
                 differences[key] = value
         return differences
 

--- a/user_sync/engine/umapi.py
+++ b/user_sync/engine/umapi.py
@@ -57,6 +57,7 @@ class RuleProcessor(object):
         'stray_list_input_path': None,
         'stray_list_output_path': None,
         'test_mode': False,
+        'update_attributes': ['firstname', 'lastname', 'email'],
         'update_user_info': False,
         'username_filter_regex': None,
     }


### PR DESCRIPTION
<!-- Don't forget to update the PR title to concisely describe the proposed changes -->

## Summary
* Since introducing username updates, we need to implement a way to control which fields are updated when updating user info
* It may not always be desirable to update usernames
* By default we should allow updates of first name, last name and email address since those have historically been updatable
* This config allows username updates to be opt-in
* UST will log a warning if a user has an attribute that can potentially be updated and the config is set up not to update it

<!-- Document the testing procedure for the PR reviewer. Attach any relevant configuration files and
     document invocation options -->
## Testing Steps
* Add the following config under `adobe_users`
  ```yaml
  update_attributes:
    - lastname
    - firstname
    - email
    # - username
  ```
* Run sync with `update_user_info` enabled
* Test the updating of different attributes with regard to the `update_attriubtes` list

<!-- REQUIRED: Link to all bugs that this PR fixes, one link per line -->
<!-- If there is no related issue, please create one and link it here before submitting the PR -->
Fixes #775
