### PR TITLE
Use the directory username to search for accounts when changing the email attribute

### DIFF
--- a/user_sync/engine/umapi.py
+++ b/user_sync/engine/umapi.py
@@ -894,7 +894,13 @@ class RuleProcessor(object):
                 directory_user['email'] = umapi_user['email']
                 directory_user['username'] = umapi_user['email']
 
-        commands = user_sync.connector.connector_umapi.Commands(directory_user['email'], directory_user['domain'])
+        # if the username is not an email address, matches in both directories, and the email address is changing, then we need to lookup by username.
+        if '@' not in directory_user['username'] and directory_user['username'] == umapi_user['username'] and normalize_string(directory_user['email']) != normalize_string(umapi_user['email']):
+            user_lookup = directory_user['username']
+        else:
+            user_lookup = directory_user['email']
+
+        commands = user_sync.connector.connector_umapi.Commands(user_lookup, directory_user['domain'])
         commands.update_user(attributes_to_update)
         commands.remove_groups(groups_to_remove)
         commands.add_groups(groups_to_add)


### PR DESCRIPTION
<!-- Don't forget to update the PR title to concisely describe the proposed changes -->

## Summary
* When the username is not changing, is not an email address, and the email attribute is different between the directory and umapi accounts, use the username as the lookup value for the umapi update command. Otherwise, continue to use the directory email address.

<!-- Document the testing procedure for the PR reviewer. Attach any relevant configuration files and
     document invocation options -->
## Testing Steps
[user-sync-config.yml](https://github.com/user-attachments/files/24240601/user-sync-config.yml)
[connector-umapi.yml](https://github.com/user-attachments/files/24240677/connector-umapi.yml)
[connector-ldap.yml](https://github.com/user-attachments/files/24240602/connector-ldap.yml)

* In a tenant with FereratedIDs, use the sync tool to create an account where the username is a non-email identifier.
* Update the directory source so that the email attribute is changed, but the identifier attribute is not.
* Rerun the sync tool to update the email address of the account.
  * The sync tool from the current codebase will fail, unable to find the account in Adobe using the new email address.
  * The sync tool with this patch will succeed by using the username attribute to update the account.

NOTE: This has worked against my production tenant. Project maintainers and Adobe employees may PM me with their GitHub handle if they need details about my tenant.

<!-- REQUIRED: Link to all bugs that this PR fixes, one link per line -->
<!-- If there is no related issue, please create one and link it here before submitting the PR -->
Fixes #827 
